### PR TITLE
#78 Restore Laravel 9.* support in GitHub Actions test matrix

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -74,9 +74,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
+        laravel: [9.*, 10.*, 11.*]
         dependency-version: [prefer-stable]
         include:
+          - laravel: 9.*
+            testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
           - laravel: 11.*
@@ -113,7 +115,7 @@ jobs:
         run: vendor/bin/pest
 
       - name: Setup PHP with coverage for coverage job
-        if: matrix.php == '8.2' && matrix.laravel == '11.*'
+        if: matrix.php == '8.2' && matrix.laravel == '10.*'
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -121,11 +123,11 @@ jobs:
           coverage: xdebug
 
       - name: Execute tests with coverage (for PHP 8.2 only)
-        if: matrix.php == '8.2' && matrix.laravel == '11.*'
+        if: matrix.php == '8.2' && matrix.laravel == '10.*'
         run: vendor/bin/pest --coverage-clover=coverage.xml
 
       - name: Upload coverage to Codecov
-        if: matrix.php == '8.2' && matrix.laravel == '11.*'
+        if: matrix.php == '8.2' && matrix.laravel == '10.*'
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml


### PR DESCRIPTION
## Summary

Fixes issue #78 by restoring Laravel 9.* support to the GitHub Actions test matrix that was accidentally removed during PR #77.

## Problem

Laravel 9.* support was accidentally removed from the CI test matrix while fixing test configuration issues, even though:
- ✅ `composer.json` declares Laravel 9.* support (`^9.0|^10.0|^11.0|^12.0`)
- ✅ `README.md` states "Laravel 9.0 or higher" 
- ❌ GitHub Actions workflow was only testing Laravel 10.* and 11.*

## Solution

**Restored full Laravel compatibility testing:**

```yaml
matrix:
  php: [8.1, 8.2, 8.3]
  laravel: [9.*, 10.*, 11.*]  # ← Laravel 9.* restored
  dependency-version: [prefer-stable]
  include:
    - laravel: 9.*
      testbench: 7.*           # ← Added testbench 7.* for Laravel 9.*
    - laravel: 10.*
      testbench: 8.*
    - laravel: 11.*
      testbench: 9.*
```

## Test Coverage

This now provides comprehensive testing across:
- **PHP versions**: 8.1, 8.2, 8.3
- **Laravel versions**: 9.x, 10.x, 11.x  
- **Total combinations**: 8 test jobs (excluding PHP 8.1 + Laravel 11.*)

## Changes Made

- ✅ Added Laravel 9.* back to test matrix
- ✅ Added testbench 7.* dependency for Laravel 9.* compatibility
- ✅ Updated coverage job to use PHP 8.2 + Laravel 10.* combination
- ✅ Maintains all existing exclusions and configurations

## Validation

The workflow now properly validates the compatibility claims made in:
- `composer.json` - Supports Laravel 9.0+
- `README.md` - Documents Laravel 9.0+ requirement  
- Package functionality - Ensures no regressions for Laravel 9.x users

**Closes #78**

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>