### PR TITLE
#62 Add comprehensive v1/manufacturers resource to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The SDK provides access to the following Trading Card API resources:
 | **Teams** | Team data | `get()`, `getList()`, `create()` |
 | **Genres** | Card categories/types | `get()`, `getList()` |
 | **Brands** | Trading card brands | `get()`, `list()`, `create()`, `update()`, `delete()` |
+| **Manufacturers** | Trading card manufacturers | `get()`, `list()`, `create()`, `update()`, `delete()` |
 | **Attributes** | Card attributes | `get()`, `getList()` |
 
 ## 🔧 Configuration

--- a/src/Models/Manufacturer.php
+++ b/src/Models/Manufacturer.php
@@ -5,4 +5,17 @@ namespace CardTechie\TradingCardApiSdk\Models;
 /**
  * Class Manufacturer
  */
-class Manufacturer extends Model {}
+class Manufacturer extends Model
+{
+    /**
+     * Retrieve the sets associated with this manufacturer.
+     */
+    public function sets(): array
+    {
+        if (array_key_exists('sets', $this->relationships)) {
+            return $this->relationships['sets'];
+        }
+
+        return [];
+    }
+}

--- a/src/Resources/Manufacturer.php
+++ b/src/Resources/Manufacturer.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace CardTechie\TradingCardApiSdk\Resources;
+
+use CardTechie\TradingCardApiSdk\Models\Manufacturer as ManufacturerModel;
+use CardTechie\TradingCardApiSdk\Resources\Traits\ApiRequest;
+use CardTechie\TradingCardApiSdk\Response;
+use GuzzleHttp\Client;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+/**
+ * Class Manufacturer
+ */
+class Manufacturer
+{
+    use ApiRequest;
+
+    /**
+     * Manufacturer constructor.
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Create a manufacturer with the passed in attributes
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function create(array $attributes = [], array $relationships = []): ManufacturerModel
+    {
+        $request = [
+            'json' => [
+                'data' => [
+                    'type' => 'manufacturers',
+                ],
+            ],
+        ];
+
+        if (count($attributes)) {
+            $request['json']['data']['attributes'] = $attributes;
+        }
+
+        if (count($relationships)) {
+            $request['json']['data']['relationships'] = $relationships;
+        }
+
+        $response = $this->makeRequest('/v1/manufacturers', 'POST', $request);
+        $formattedResponse = new Response(json_encode($response));
+
+        return $formattedResponse->mainObject;
+    }
+
+    /**
+     * Retrieve a manufacturer by ID
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function get(string $id, array $params = []): ManufacturerModel
+    {
+        $defaultParams = [
+            'include' => '',
+        ];
+        $params = array_merge($defaultParams, $params);
+
+        $url = sprintf('/v1/manufacturers/%s?%s', $id, http_build_query($params));
+        $response = $this->makeRequest($url);
+        $formattedResponse = new Response(json_encode($response));
+
+        return $formattedResponse->mainObject;
+    }
+
+    /**
+     * Retrieve a list of manufacturers
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function list(array $params = []): LengthAwarePaginator
+    {
+        $defaultParams = [
+            'limit' => 50,
+            'page' => 1,
+            'pageName' => 'page',
+        ];
+        $params = array_merge($defaultParams, $params);
+
+        $url = sprintf('/v1/manufacturers?%s', http_build_query($params));
+        $response = $this->makeRequest($url);
+
+        $totalPages = $response->meta->pagination->total;
+        $perPage = $response->meta->pagination->per_page;
+        $page = $response->meta->pagination->current_page;
+        $options = [
+            'path' => LengthAwarePaginator::resolveCurrentPath(),
+            'pageName' => $params['pageName'],
+        ];
+        $parsedResponse = Response::parse(json_encode($response));
+
+        return new LengthAwarePaginator($parsedResponse, $totalPages, $perPage, $page, $options);
+    }
+
+    /**
+     * Update a manufacturer
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function update(string $id, array $attributes = [], array $relationships = []): ManufacturerModel
+    {
+        $url = sprintf('/v1/manufacturers/%s', $id);
+        $request = [
+            'json' => [
+                'data' => [
+                    'type' => 'manufacturers',
+                    'id' => $id,
+                ],
+            ],
+        ];
+
+        if (count($attributes)) {
+            $request['json']['data']['attributes'] = $attributes;
+        }
+
+        if (count($relationships)) {
+            $request['json']['data']['relationships'] = $relationships;
+        }
+
+        $response = $this->makeRequest($url, 'PUT', $request);
+        $formattedResponse = new Response(json_encode($response));
+
+        return $formattedResponse->mainObject;
+    }
+
+    /**
+     * Delete a manufacturer
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function delete(string $id): void
+    {
+        $url = '/v1/manufacturers/'.$id;
+        $this->makeRequest($url, 'DELETE');
+    }
+}

--- a/src/TradingCardApi.php
+++ b/src/TradingCardApi.php
@@ -6,6 +6,7 @@ use CardTechie\TradingCardApiSdk\Resources\Attribute;
 use CardTechie\TradingCardApiSdk\Resources\Brand;
 use CardTechie\TradingCardApiSdk\Resources\Card;
 use CardTechie\TradingCardApiSdk\Resources\Genre;
+use CardTechie\TradingCardApiSdk\Resources\Manufacturer;
 use CardTechie\TradingCardApiSdk\Resources\Player;
 use CardTechie\TradingCardApiSdk\Resources\Playerteam;
 use CardTechie\TradingCardApiSdk\Resources\Set;
@@ -101,5 +102,13 @@ class TradingCardApi
     public function brand(): Brand
     {
         return new Brand($this->client);
+    }
+
+    /**
+     * Retrieve the manufacturer resource.
+     */
+    public function manufacturer(): Manufacturer
+    {
+        return new Manufacturer($this->client);
     }
 }

--- a/tests/Models/ManufacturerModelTest.php
+++ b/tests/Models/ManufacturerModelTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Models\Manufacturer;
+use CardTechie\TradingCardApiSdk\Models\Set;
+
+beforeEach(function () {
+    // Set up configuration
+    $this->app['config']->set('tradingcardapi', [
+        'url' => 'https://api.example.com',
+        'ssl_verify' => true,
+    ]);
+});
+
+it('can be instantiated with attributes', function () {
+    $attributes = [
+        'id' => '123',
+        'name' => 'Test Manufacturer',
+        'description' => 'A test manufacturer description',
+    ];
+
+    $manufacturer = new Manufacturer($attributes);
+
+    expect($manufacturer->id)->toBe('123');
+    expect($manufacturer->name)->toBe('Test Manufacturer');
+    expect($manufacturer->description)->toBe('A test manufacturer description');
+});
+
+it('can be instantiated without attributes', function () {
+    $manufacturer = new Manufacturer;
+
+    expect($manufacturer)->toBeInstanceOf(Manufacturer::class);
+});
+
+it('returns empty array when no sets', function () {
+    $manufacturer = new Manufacturer(['id' => '123', 'name' => 'Test Manufacturer']);
+
+    $sets = $manufacturer->sets();
+
+    expect($sets)->toBe([]);
+});
+
+it('returns sets array when sets relationship exists', function () {
+    $manufacturer = new Manufacturer(['id' => '123', 'name' => 'Test Manufacturer']);
+
+    $setData = [
+        new Set(['id' => '1', 'name' => 'Set 1']),
+        new Set(['id' => '2', 'name' => 'Set 2']),
+    ];
+
+    $manufacturer->setRelationships(['sets' => $setData]);
+
+    $sets = $manufacturer->sets();
+
+    expect($sets)->toHaveCount(2);
+    expect($sets[0])->toBeInstanceOf(Set::class);
+    expect($sets[0]->name)->toBe('Set 1');
+    expect($sets[1])->toBeInstanceOf(Set::class);
+    expect($sets[1]->name)->toBe('Set 2');
+});
+
+it('handles null attributes gracefully', function () {
+    $manufacturer = new Manufacturer(['id' => '123', 'name' => null]);
+
+    expect($manufacturer->id)->toBe('123');
+    expect($manufacturer->name)->toBeNull();
+});
+
+it('magic get returns null for non-existent attributes', function () {
+    $manufacturer = new Manufacturer(['id' => '123']);
+
+    expect($manufacturer->nonExistentProperty)->toBeNull();
+});
+
+it('magic isset works correctly', function () {
+    $manufacturer = new Manufacturer(['id' => '123', 'name' => 'Test Manufacturer']);
+
+    expect(isset($manufacturer->id))->toBeTrue();
+    expect(isset($manufacturer->name))->toBeTrue();
+    expect(isset($manufacturer->nonExistentProperty))->toBeFalse();
+});
+
+it('converts to string correctly', function () {
+    $manufacturer = new Manufacturer(['id' => '123', 'name' => 'Test Manufacturer']);
+
+    $jsonString = (string) $manufacturer;
+    $decodedJson = json_decode($jsonString, true);
+
+    expect($decodedJson)->toHaveKey('id', '123');
+    expect($decodedJson)->toHaveKey('name', 'Test Manufacturer');
+});
+
+it('converts to string with relationships', function () {
+    $manufacturer = new Manufacturer(['id' => '123', 'name' => 'Test Manufacturer']);
+
+    $setData = [
+        new Set(['id' => '1', 'name' => 'Set 1']),
+    ];
+
+    $manufacturer->setRelationships(['sets' => $setData]);
+
+    $jsonString = (string) $manufacturer;
+    $decodedJson = json_decode($jsonString, true);
+
+    expect($decodedJson)->toHaveKey('id', '123');
+    expect($decodedJson)->toHaveKey('name', 'Test Manufacturer');
+    expect($decodedJson)->toHaveKey('sets');
+    expect($decodedJson['sets'])->toBeArray();
+    expect($decodedJson['sets'])->toHaveCount(1);
+});

--- a/tests/Resources/ManufacturerResourceTest.php
+++ b/tests/Resources/ManufacturerResourceTest.php
@@ -1,0 +1,266 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Models\Manufacturer as ManufacturerModel;
+use CardTechie\TradingCardApiSdk\Resources\Manufacturer;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+beforeEach(function () {
+    // Set up configuration
+    $this->app['config']->set('tradingcardapi', [
+        'url' => 'https://api.example.com',
+        'ssl_verify' => true,
+        'client_id' => 'test-client-id',
+        'client_secret' => 'test-client-secret',
+    ]);
+
+    // Pre-populate cache with token to avoid OAuth requests
+    cache()->put('tcapi_token', 'test-token', 60);
+
+    $this->mockHandler = new MockHandler;
+    $handlerStack = HandlerStack::create($this->mockHandler);
+    $this->client = new Client(['handler' => $handlerStack]);
+    $this->manufacturerResource = new Manufacturer($this->client);
+});
+
+it('can be instantiated with client', function () {
+    expect($this->manufacturerResource)->toBeInstanceOf(Manufacturer::class);
+});
+
+it('can create a manufacturer', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'manufacturers',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Test Manufacturer',
+                    'description' => 'A test manufacturer',
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = [
+        'name' => 'Test Manufacturer',
+        'description' => 'A test manufacturer',
+    ];
+
+    $result = $this->manufacturerResource->create($attributes);
+
+    expect($result)->toBeInstanceOf(ManufacturerModel::class);
+});
+
+it('can create manufacturer without attributes', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'manufacturers',
+                'id' => '123',
+                'attributes' => [],
+            ],
+        ]))
+    );
+
+    $result = $this->manufacturerResource->create();
+
+    expect($result)->toBeInstanceOf(ManufacturerModel::class);
+});
+
+it('can create a manufacturer with relationships', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'manufacturers',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Test Manufacturer',
+                ],
+                'relationships' => [
+                    'brand' => [
+                        'data' => ['type' => 'brands', 'id' => '456'],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = ['name' => 'Test Manufacturer'];
+    $relationships = [
+        'brand' => [
+            'data' => ['type' => 'brands', 'id' => '456'],
+        ],
+    ];
+
+    $result = $this->manufacturerResource->create($attributes, $relationships);
+
+    expect($result)->toBeInstanceOf(ManufacturerModel::class);
+});
+
+it('can get a manufacturer by id', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'manufacturers',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Test Manufacturer',
+                    'description' => 'A test manufacturer',
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->manufacturerResource->get('123');
+
+    expect($result)->toBeInstanceOf(ManufacturerModel::class);
+});
+
+it('can get a manufacturer by id with custom params', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'manufacturers',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Test Manufacturer',
+                    'description' => 'A test manufacturer',
+                ],
+            ],
+        ]))
+    );
+
+    $params = ['include' => 'sets'];
+    $result = $this->manufacturerResource->get('123', $params);
+
+    expect($result)->toBeInstanceOf(ManufacturerModel::class);
+});
+
+it('can get a list of manufacturers', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                [
+                    'type' => 'manufacturers',
+                    'id' => '123',
+                    'attributes' => [
+                        'name' => 'Manufacturer 1',
+                    ],
+                ],
+                [
+                    'type' => 'manufacturers',
+                    'id' => '124',
+                    'attributes' => [
+                        'name' => 'Manufacturer 2',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'total' => 100,
+                    'per_page' => 50,
+                    'current_page' => 1,
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->manufacturerResource->list();
+
+    expect($result)->toBeInstanceOf(LengthAwarePaginator::class);
+});
+
+it('can get a list of manufacturers with custom params', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                [
+                    'type' => 'manufacturers',
+                    'id' => '123',
+                    'attributes' => [
+                        'name' => 'Manufacturer 1',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'total' => 100,
+                    'per_page' => 25,
+                    'current_page' => 2,
+                ],
+            ],
+        ]))
+    );
+
+    $params = ['limit' => 25, 'page' => 2];
+    $result = $this->manufacturerResource->list($params);
+
+    expect($result)->toBeInstanceOf(LengthAwarePaginator::class);
+});
+
+it('can update a manufacturer', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'manufacturers',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Updated Manufacturer',
+                    'description' => 'Updated description',
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = [
+        'name' => 'Updated Manufacturer',
+        'description' => 'Updated description',
+    ];
+
+    $result = $this->manufacturerResource->update('123', $attributes);
+
+    expect($result)->toBeInstanceOf(ManufacturerModel::class);
+});
+
+it('can update a manufacturer with relationships', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'manufacturers',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Updated Manufacturer',
+                ],
+                'relationships' => [
+                    'brand' => [
+                        'data' => ['type' => 'brands', 'id' => '789'],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = ['name' => 'Updated Manufacturer'];
+    $relationships = [
+        'brand' => [
+            'data' => ['type' => 'brands', 'id' => '789'],
+        ],
+    ];
+
+    $result = $this->manufacturerResource->update('123', $attributes, $relationships);
+
+    expect($result)->toBeInstanceOf(ManufacturerModel::class);
+});
+
+it('can delete a manufacturer', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(204, [], '')
+    );
+
+    $this->manufacturerResource->delete('123');
+
+    expect(true)->toBeTrue(); // If no exception is thrown, the test passes
+});

--- a/tests/TradingCardApiTest.php
+++ b/tests/TradingCardApiTest.php
@@ -4,6 +4,7 @@ use CardTechie\TradingCardApiSdk\Resources\Attribute;
 use CardTechie\TradingCardApiSdk\Resources\Brand;
 use CardTechie\TradingCardApiSdk\Resources\Card;
 use CardTechie\TradingCardApiSdk\Resources\Genre;
+use CardTechie\TradingCardApiSdk\Resources\Manufacturer;
 use CardTechie\TradingCardApiSdk\Resources\Player;
 use CardTechie\TradingCardApiSdk\Resources\Playerteam;
 use CardTechie\TradingCardApiSdk\Resources\Set;
@@ -72,6 +73,12 @@ it('returns brand resource', function () {
     $api = new TradingCardApi;
     $brand = $api->brand();
     expect($brand)->toBeInstanceOf(Brand::class);
+});
+
+it('returns manufacturer resource', function () {
+    $api = new TradingCardApi;
+    $manufacturer = $api->manufacturer();
+    expect($manufacturer)->toBeInstanceOf(Manufacturer::class);
 });
 
 it('creates guzzle client with correct configuration', function () {


### PR DESCRIPTION
## Summary
Implements issue #62 by adding comprehensive Manufacturer resource support to the PHP SDK, providing full CRUD operations for the v1/manufacturers API endpoint.

### Changes Made
- ✅ **Manufacturer Resource Class** (`src/Resources/Manufacturer.php`)
  - Full CRUD operations: `create()`, `get()`, `list()`, `update()`, `delete()`
  - Support for attributes and relationships in create/update operations
  - Paginated list results with customizable parameters
  - Uses modern v1 API endpoints (`/v1/manufacturers`)
  - Follows established SDK patterns with proper error handling

- ✅ **Manufacturer Model Class** (`src/Models/Manufacturer.php`)
  - Enhanced existing basic model with relationship methods
  - Added `sets()` method to access related sets
  - Proper relationship handling and data access patterns

- ✅ **TradingCardApi Integration**
  - Added `manufacturer()` method to main API class
  - Updated imports to include Manufacturer resource
  - Maintains consistency with other v1 resource methods

- ✅ **Comprehensive Test Coverage**
  - **Manufacturer Resource Tests**: 11 test cases covering all CRUD operations
  - **Manufacturer Model Tests**: 9 test cases for model functionality
  - **Integration Tests**: Updated TradingCardApiTest with manufacturer resource test
  - All tests use proper mocking and follow existing patterns

- ✅ **Documentation Updates**
  - Added Manufacturer resource to README.md Available Resources table
  - Listed all supported methods with proper formatting

### Test Results
- ✅ All 173 tests passing (289 assertions)
- ✅ Follows established code patterns and conventions
- ✅ Uses modern v1 API endpoints (non-deprecated)
- ✅ Maintains consistency with Brand resource implementation

### Usage Example
```php
use CardTechie\TradingCardApiSdk\TradingCardApi;

$api = new TradingCardApi();

// Get a specific manufacturer
$manufacturer = $api->manufacturer()->get('manufacturer-id');

// List manufacturers with pagination
$manufacturers = $api->manufacturer()->list(['limit' => 25, 'page' => 2]);

// Create a new manufacturer
$manufacturer = $api->manufacturer()->create([
    'name' => 'New Manufacturer',
    'description' => 'Manufacturer description'
]);

// Update a manufacturer
$manufacturer = $api->manufacturer()->update('manufacturer-id', [
    'name' => 'Updated Manufacturer Name'
]);

// Delete a manufacturer
$api->manufacturer()->delete('manufacturer-id');
```

## Test plan
- [x] All existing tests continue to pass
- [x] New Manufacturer resource tests cover all CRUD operations
- [x] New Manufacturer model tests cover data access and relationships
- [x] Integration test verifies TradingCardApi returns correct Manufacturer resource
- [x] Documentation updated to reflect new functionality
- [x] Uses modern v1 API endpoints consistently

## Related
- Builds on the patterns established in PR #80 (Brand resource)
- Part of the v1 API endpoint migration strategy
- Follows modern SDK architecture with comprehensive testing

🤖 Generated with [Claude Code](https://claude.ai/code)