### PR TITLE
#63 Add comprehensive v1/years resource to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The SDK provides access to the following Trading Card API resources:
 | **Genres** | Card categories/types | `get()`, `getList()` |
 | **Brands** | Trading card brands | `get()`, `list()`, `create()`, `update()`, `delete()` |
 | **Manufacturers** | Trading card manufacturers | `get()`, `list()`, `create()`, `update()`, `delete()` |
+| **Years** | Trading card years | `get()`, `list()`, `create()`, `update()`, `delete()` |
 | **Attributes** | Card attributes | `get()`, `getList()` |
 
 ## 🔧 Configuration

--- a/src/Models/Year.php
+++ b/src/Models/Year.php
@@ -5,4 +5,17 @@ namespace CardTechie\TradingCardApiSdk\Models;
 /**
  * Class Year
  */
-class Year extends Model {}
+class Year extends Model
+{
+    /**
+     * Retrieve the sets associated with this year.
+     */
+    public function sets(): array
+    {
+        if (array_key_exists('sets', $this->relationships)) {
+            return $this->relationships['sets'];
+        }
+
+        return [];
+    }
+}

--- a/src/Resources/Year.php
+++ b/src/Resources/Year.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace CardTechie\TradingCardApiSdk\Resources;
+
+use CardTechie\TradingCardApiSdk\Models\Year as YearModel;
+use CardTechie\TradingCardApiSdk\Resources\Traits\ApiRequest;
+use CardTechie\TradingCardApiSdk\Response;
+use GuzzleHttp\Client;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+/**
+ * Class Year
+ */
+class Year
+{
+    use ApiRequest;
+
+    /**
+     * Year constructor.
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Create a year with the passed in attributes
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function create(array $attributes = [], array $relationships = []): YearModel
+    {
+        $request = [
+            'json' => [
+                'data' => [
+                    'type' => 'years',
+                ],
+            ],
+        ];
+
+        if (count($attributes)) {
+            $request['json']['data']['attributes'] = $attributes;
+        }
+
+        if (count($relationships)) {
+            $request['json']['data']['relationships'] = $relationships;
+        }
+
+        $response = $this->makeRequest('/v1/years', 'POST', $request);
+        $formattedResponse = new Response(json_encode($response));
+
+        return $formattedResponse->mainObject;
+    }
+
+    /**
+     * Retrieve a year by ID
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function get(string $id, array $params = []): YearModel
+    {
+        $defaultParams = [
+            'include' => '',
+        ];
+        $params = array_merge($defaultParams, $params);
+
+        $url = sprintf('/v1/years/%s?%s', $id, http_build_query($params));
+        $response = $this->makeRequest($url);
+        $formattedResponse = new Response(json_encode($response));
+
+        return $formattedResponse->mainObject;
+    }
+
+    /**
+     * Retrieve a list of years
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function list(array $params = []): LengthAwarePaginator
+    {
+        $defaultParams = [
+            'limit' => 50,
+            'page' => 1,
+            'pageName' => 'page',
+        ];
+        $params = array_merge($defaultParams, $params);
+
+        $url = sprintf('/v1/years?%s', http_build_query($params));
+        $response = $this->makeRequest($url);
+
+        $totalPages = $response->meta->pagination->total;
+        $perPage = $response->meta->pagination->per_page;
+        $page = $response->meta->pagination->current_page;
+        $options = [
+            'path' => LengthAwarePaginator::resolveCurrentPath(),
+            'pageName' => $params['pageName'],
+        ];
+        $parsedResponse = Response::parse(json_encode($response));
+
+        return new LengthAwarePaginator($parsedResponse, $totalPages, $perPage, $page, $options);
+    }
+
+    /**
+     * Update a year
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function update(string $id, array $attributes = [], array $relationships = []): YearModel
+    {
+        $url = sprintf('/v1/years/%s', $id);
+        $request = [
+            'json' => [
+                'data' => [
+                    'type' => 'years',
+                    'id' => $id,
+                ],
+            ],
+        ];
+
+        if (count($attributes)) {
+            $request['json']['data']['attributes'] = $attributes;
+        }
+
+        if (count($relationships)) {
+            $request['json']['data']['relationships'] = $relationships;
+        }
+
+        $response = $this->makeRequest($url, 'PUT', $request);
+        $formattedResponse = new Response(json_encode($response));
+
+        return $formattedResponse->mainObject;
+    }
+
+    /**
+     * Delete a year
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function delete(string $id): void
+    {
+        $url = '/v1/years/'.$id;
+        $this->makeRequest($url, 'DELETE');
+    }
+}

--- a/src/TradingCardApi.php
+++ b/src/TradingCardApi.php
@@ -11,6 +11,7 @@ use CardTechie\TradingCardApiSdk\Resources\Player;
 use CardTechie\TradingCardApiSdk\Resources\Playerteam;
 use CardTechie\TradingCardApiSdk\Resources\Set;
 use CardTechie\TradingCardApiSdk\Resources\Team;
+use CardTechie\TradingCardApiSdk\Resources\Year;
 use GuzzleHttp\Client;
 
 /**
@@ -110,5 +111,13 @@ class TradingCardApi
     public function manufacturer(): Manufacturer
     {
         return new Manufacturer($this->client);
+    }
+
+    /**
+     * Retrieve the year resource.
+     */
+    public function year(): Year
+    {
+        return new Year($this->client);
     }
 }

--- a/tests/Models/YearModelTest.php
+++ b/tests/Models/YearModelTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Models\Set;
+use CardTechie\TradingCardApiSdk\Models\Year;
+
+beforeEach(function () {
+    // Set up configuration
+    $this->app['config']->set('tradingcardapi', [
+        'url' => 'https://api.example.com',
+        'ssl_verify' => true,
+    ]);
+});
+
+it('can be instantiated with attributes', function () {
+    $attributes = [
+        'id' => '123',
+        'year' => '2023',
+        'description' => 'A test year description',
+    ];
+
+    $year = new Year($attributes);
+
+    expect($year->id)->toBe('123');
+    expect($year->year)->toBe('2023');
+    expect($year->description)->toBe('A test year description');
+});
+
+it('can be instantiated without attributes', function () {
+    $year = new Year;
+
+    expect($year)->toBeInstanceOf(Year::class);
+});
+
+it('returns empty array when no sets', function () {
+    $year = new Year(['id' => '123', 'year' => '2023']);
+
+    $sets = $year->sets();
+
+    expect($sets)->toBe([]);
+});
+
+it('returns sets array when sets relationship exists', function () {
+    $year = new Year(['id' => '123', 'year' => '2023']);
+
+    $setData = [
+        new Set(['id' => '1', 'name' => 'Set 1']),
+        new Set(['id' => '2', 'name' => 'Set 2']),
+    ];
+
+    $year->setRelationships(['sets' => $setData]);
+
+    $sets = $year->sets();
+
+    expect($sets)->toHaveCount(2);
+    expect($sets[0])->toBeInstanceOf(Set::class);
+    expect($sets[0]->name)->toBe('Set 1');
+    expect($sets[1])->toBeInstanceOf(Set::class);
+    expect($sets[1]->name)->toBe('Set 2');
+});
+
+it('handles null attributes gracefully', function () {
+    $year = new Year(['id' => '123', 'year' => null]);
+
+    expect($year->id)->toBe('123');
+    expect($year->year)->toBeNull();
+});
+
+it('magic get returns null for non-existent attributes', function () {
+    $year = new Year(['id' => '123']);
+
+    expect($year->nonExistentProperty)->toBeNull();
+});
+
+it('magic isset works correctly', function () {
+    $year = new Year(['id' => '123', 'year' => '2023']);
+
+    expect(isset($year->id))->toBeTrue();
+    expect(isset($year->year))->toBeTrue();
+    expect(isset($year->nonExistentProperty))->toBeFalse();
+});
+
+it('converts to string correctly', function () {
+    $year = new Year(['id' => '123', 'year' => '2023']);
+
+    $jsonString = (string) $year;
+    $decodedJson = json_decode($jsonString, true);
+
+    expect($decodedJson)->toHaveKey('id', '123');
+    expect($decodedJson)->toHaveKey('year', '2023');
+});
+
+it('converts to string with relationships', function () {
+    $year = new Year(['id' => '123', 'year' => '2023']);
+
+    $setData = [
+        new Set(['id' => '1', 'name' => 'Set 1']),
+    ];
+
+    $year->setRelationships(['sets' => $setData]);
+
+    $jsonString = (string) $year;
+    $decodedJson = json_decode($jsonString, true);
+
+    expect($decodedJson)->toHaveKey('id', '123');
+    expect($decodedJson)->toHaveKey('year', '2023');
+    expect($decodedJson)->toHaveKey('sets');
+    expect($decodedJson['sets'])->toBeArray();
+    expect($decodedJson['sets'])->toHaveCount(1);
+});

--- a/tests/Resources/YearResourceTest.php
+++ b/tests/Resources/YearResourceTest.php
@@ -1,0 +1,266 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Models\Year as YearModel;
+use CardTechie\TradingCardApiSdk\Resources\Year;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+beforeEach(function () {
+    // Set up configuration
+    $this->app['config']->set('tradingcardapi', [
+        'url' => 'https://api.example.com',
+        'ssl_verify' => true,
+        'client_id' => 'test-client-id',
+        'client_secret' => 'test-client-secret',
+    ]);
+
+    // Pre-populate cache with token to avoid OAuth requests
+    cache()->put('tcapi_token', 'test-token', 60);
+
+    $this->mockHandler = new MockHandler;
+    $handlerStack = HandlerStack::create($this->mockHandler);
+    $this->client = new Client(['handler' => $handlerStack]);
+    $this->yearResource = new Year($this->client);
+});
+
+it('can be instantiated with client', function () {
+    expect($this->yearResource)->toBeInstanceOf(Year::class);
+});
+
+it('can create a year', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'years',
+                'id' => '123',
+                'attributes' => [
+                    'year' => '2023',
+                    'description' => 'A test year',
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = [
+        'year' => '2023',
+        'description' => 'A test year',
+    ];
+
+    $result = $this->yearResource->create($attributes);
+
+    expect($result)->toBeInstanceOf(YearModel::class);
+});
+
+it('can create year without attributes', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'years',
+                'id' => '123',
+                'attributes' => [],
+            ],
+        ]))
+    );
+
+    $result = $this->yearResource->create();
+
+    expect($result)->toBeInstanceOf(YearModel::class);
+});
+
+it('can create a year with relationships', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'years',
+                'id' => '123',
+                'attributes' => [
+                    'year' => '2023',
+                ],
+                'relationships' => [
+                    'sets' => [
+                        'data' => [['type' => 'sets', 'id' => '456']],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = ['year' => '2023'];
+    $relationships = [
+        'sets' => [
+            'data' => [['type' => 'sets', 'id' => '456']],
+        ],
+    ];
+
+    $result = $this->yearResource->create($attributes, $relationships);
+
+    expect($result)->toBeInstanceOf(YearModel::class);
+});
+
+it('can get a year by id', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'years',
+                'id' => '123',
+                'attributes' => [
+                    'year' => '2023',
+                    'description' => 'A test year',
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->yearResource->get('123');
+
+    expect($result)->toBeInstanceOf(YearModel::class);
+});
+
+it('can get a year by id with custom params', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'years',
+                'id' => '123',
+                'attributes' => [
+                    'year' => '2023',
+                    'description' => 'A test year',
+                ],
+            ],
+        ]))
+    );
+
+    $params = ['include' => 'sets'];
+    $result = $this->yearResource->get('123', $params);
+
+    expect($result)->toBeInstanceOf(YearModel::class);
+});
+
+it('can get a list of years', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                [
+                    'type' => 'years',
+                    'id' => '123',
+                    'attributes' => [
+                        'year' => '2023',
+                    ],
+                ],
+                [
+                    'type' => 'years',
+                    'id' => '124',
+                    'attributes' => [
+                        'year' => '2024',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'total' => 100,
+                    'per_page' => 50,
+                    'current_page' => 1,
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->yearResource->list();
+
+    expect($result)->toBeInstanceOf(LengthAwarePaginator::class);
+});
+
+it('can get a list of years with custom params', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                [
+                    'type' => 'years',
+                    'id' => '123',
+                    'attributes' => [
+                        'year' => '2023',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'total' => 100,
+                    'per_page' => 25,
+                    'current_page' => 2,
+                ],
+            ],
+        ]))
+    );
+
+    $params = ['limit' => 25, 'page' => 2];
+    $result = $this->yearResource->list($params);
+
+    expect($result)->toBeInstanceOf(LengthAwarePaginator::class);
+});
+
+it('can update a year', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'years',
+                'id' => '123',
+                'attributes' => [
+                    'year' => '2024',
+                    'description' => 'Updated description',
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = [
+        'year' => '2024',
+        'description' => 'Updated description',
+    ];
+
+    $result = $this->yearResource->update('123', $attributes);
+
+    expect($result)->toBeInstanceOf(YearModel::class);
+});
+
+it('can update a year with relationships', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'years',
+                'id' => '123',
+                'attributes' => [
+                    'year' => '2024',
+                ],
+                'relationships' => [
+                    'sets' => [
+                        'data' => [['type' => 'sets', 'id' => '789']],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = ['year' => '2024'];
+    $relationships = [
+        'sets' => [
+            'data' => [['type' => 'sets', 'id' => '789']],
+        ],
+    ];
+
+    $result = $this->yearResource->update('123', $attributes, $relationships);
+
+    expect($result)->toBeInstanceOf(YearModel::class);
+});
+
+it('can delete a year', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(204, [], '')
+    );
+
+    $this->yearResource->delete('123');
+
+    expect(true)->toBeTrue(); // If no exception is thrown, the test passes
+});

--- a/tests/TradingCardApiTest.php
+++ b/tests/TradingCardApiTest.php
@@ -9,6 +9,7 @@ use CardTechie\TradingCardApiSdk\Resources\Player;
 use CardTechie\TradingCardApiSdk\Resources\Playerteam;
 use CardTechie\TradingCardApiSdk\Resources\Set;
 use CardTechie\TradingCardApiSdk\Resources\Team;
+use CardTechie\TradingCardApiSdk\Resources\Year;
 use CardTechie\TradingCardApiSdk\TradingCardApi;
 use GuzzleHttp\Client;
 
@@ -79,6 +80,12 @@ it('returns manufacturer resource', function () {
     $api = new TradingCardApi;
     $manufacturer = $api->manufacturer();
     expect($manufacturer)->toBeInstanceOf(Manufacturer::class);
+});
+
+it('returns year resource', function () {
+    $api = new TradingCardApi;
+    $year = $api->year();
+    expect($year)->toBeInstanceOf(Year::class);
 });
 
 it('creates guzzle client with correct configuration', function () {


### PR DESCRIPTION
## Summary
Implements issue #63 by adding comprehensive Year resource support to the PHP SDK, providing full CRUD operations for the v1/years API endpoint.

### Changes Made
- ✅ **Year Resource Class** (`src/Resources/Year.php`)
  - Full CRUD operations: `create()`, `get()`, `list()`, `update()`, `delete()`
  - Support for attributes and relationships in create/update operations
  - Paginated list results with customizable parameters
  - Uses modern v1 API endpoints (`/v1/years`)
  - Follows established SDK patterns with proper error handling

- ✅ **Year Model Class** (`src/Models/Year.php`)
  - Enhanced existing basic model with relationship methods
  - Added `sets()` method to access related sets
  - Proper relationship handling and data access patterns

- ✅ **TradingCardApi Integration**
  - Added `year()` method to main API class
  - Updated imports to include Year resource
  - Maintains consistency with other v1 resource methods

- ✅ **Comprehensive Test Coverage**
  - **Year Resource Tests**: 11 test cases covering all CRUD operations
  - **Year Model Tests**: 9 test cases for model functionality
  - **Integration Tests**: Updated TradingCardApiTest with year resource test
  - All tests use proper mocking and follow existing patterns

- ✅ **Documentation Updates**
  - Added Year resource to README.md Available Resources table
  - Listed all supported methods with proper formatting

### Test Results
- ✅ All 194 tests passing (328 assertions)
- ✅ Follows established code patterns and conventions
- ✅ Uses modern v1 API endpoints (non-deprecated)
- ✅ Maintains consistency with Brand and Manufacturer resource implementations

### Usage Example
```php
use CardTechie\TradingCardApiSdk\TradingCardApi;

$api = new TradingCardApi();

// Get a specific year
$year = $api->year()->get('year-id');

// List years with pagination
$years = $api->year()->list(['limit' => 25, 'page' => 2]);

// Create a new year
$year = $api->year()->create([
    'year' => '2024',
    'description' => 'Trading card year 2024'
]);

// Update a year
$year = $api->year()->update('year-id', [
    'year' => '2025',
    'description' => 'Updated year description'
]);

// Delete a year
$api->year()->delete('year-id');
```

## Test plan
- [x] All existing tests continue to pass
- [x] New Year resource tests cover all CRUD operations
- [x] New Year model tests cover data access and relationships
- [x] Integration test verifies TradingCardApi returns correct Year resource
- [x] Documentation updated to reflect new functionality
- [x] Uses modern v1 API endpoints consistently

## Related
- Builds on the patterns established in PR #80 (Brand resource) and PR #81 (Manufacturer resource)
- Part of the v1 API endpoint migration strategy (issue #59)
- Follows modern SDK architecture with comprehensive testing

🤖 Generated with [Claude Code](https://claude.ai/code)