### PR TITLE
#64 Add v1/object-attributes resource to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The SDK provides access to the following Trading Card API resources:
 | **Brands** | Trading card brands | `get()`, `list()`, `create()`, `update()`, `delete()` |
 | **Manufacturers** | Trading card manufacturers | `get()`, `list()`, `create()`, `update()`, `delete()` |
 | **Years** | Trading card years | `get()`, `list()`, `create()`, `update()`, `delete()` |
+| **ObjectAttributes** | Object attributes | `get()`, `list()`, `create()`, `update()`, `delete()` |
 | **Attributes** | Card attributes | `get()`, `getList()` |
 
 ## 🔧 Configuration

--- a/src/Models/ObjectAttribute.php
+++ b/src/Models/ObjectAttribute.php
@@ -2,7 +2,12 @@
 
 namespace CardTechie\TradingCardApiSdk\Models;
 
-/**
- * Class ObjectAttribute
- */
-class ObjectAttribute extends Model {}
+class ObjectAttribute extends Model
+{
+    public function cards(): array
+    {
+        $relationships = $this->getRelationships();
+
+        return $relationships['cards'] ?? [];
+    }
+}

--- a/src/Resources/ObjectAttribute.php
+++ b/src/Resources/ObjectAttribute.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace CardTechie\TradingCardApiSdk\Resources;
+
+use CardTechie\TradingCardApiSdk\Models\ObjectAttribute as ObjectAttributeModel;
+use CardTechie\TradingCardApiSdk\Resources\Traits\ApiRequest;
+use CardTechie\TradingCardApiSdk\Response;
+use GuzzleHttp\Client;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class ObjectAttribute
+{
+    use ApiRequest;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function create(array $attributes = [], array $relationships = []): ObjectAttributeModel
+    {
+        $request = [
+            'json' => [
+                'data' => [
+                    'type' => 'objectAttributes',
+                ],
+            ],
+        ];
+
+        if (count($attributes)) {
+            $request['json']['data']['attributes'] = $attributes;
+        }
+
+        if (count($relationships)) {
+            $request['json']['data']['relationships'] = $relationships;
+        }
+
+        $response = $this->makeRequest('/v1/object-attributes', 'POST', $request);
+        $formattedResponse = new Response(json_encode($response));
+
+        return $formattedResponse->mainObject;
+    }
+
+    public function get(string $id, array $params = []): ObjectAttributeModel
+    {
+        $url = sprintf('/v1/object-attributes/%s', $id);
+        $response = $this->makeRequest($url, 'GET', ['query' => $params]);
+        $formattedResponse = new Response(json_encode($response));
+
+        return $formattedResponse->mainObject;
+    }
+
+    public function list(array $params = []): LengthAwarePaginator
+    {
+        $defaultParams = [
+            'limit' => 50,
+            'page' => 1,
+            'pageName' => 'page',
+        ];
+        $params = array_merge($defaultParams, $params);
+
+        $url = sprintf('/v1/object-attributes?%s', http_build_query($params));
+        $response = $this->makeRequest($url);
+
+        $totalPages = $response->meta->pagination->total;
+        $perPage = $response->meta->pagination->per_page;
+        $page = $response->meta->pagination->current_page;
+        $options = [
+            'path' => LengthAwarePaginator::resolveCurrentPath(),
+            'pageName' => $params['pageName'],
+        ];
+        $parsedResponse = Response::parse(json_encode($response));
+
+        return new LengthAwarePaginator($parsedResponse, $totalPages, $perPage, $page, $options);
+    }
+
+    public function update(string $id, array $attributes = [], array $relationships = []): ObjectAttributeModel
+    {
+        $url = sprintf('/v1/object-attributes/%s', $id);
+        $request = [
+            'json' => [
+                'data' => [
+                    'type' => 'objectAttributes',
+                    'id' => $id,
+                ],
+            ],
+        ];
+
+        if (count($attributes)) {
+            $request['json']['data']['attributes'] = $attributes;
+        }
+
+        if (count($relationships)) {
+            $request['json']['data']['relationships'] = $relationships;
+        }
+
+        $response = $this->makeRequest($url, 'PUT', $request);
+        $formattedResponse = new Response(json_encode($response));
+
+        return $formattedResponse->mainObject;
+    }
+
+    public function delete(string $id): void
+    {
+        $url = sprintf('/v1/object-attributes/%s', $id);
+        $this->makeRequest($url, 'DELETE');
+    }
+}

--- a/src/TradingCardApi.php
+++ b/src/TradingCardApi.php
@@ -7,6 +7,7 @@ use CardTechie\TradingCardApiSdk\Resources\Brand;
 use CardTechie\TradingCardApiSdk\Resources\Card;
 use CardTechie\TradingCardApiSdk\Resources\Genre;
 use CardTechie\TradingCardApiSdk\Resources\Manufacturer;
+use CardTechie\TradingCardApiSdk\Resources\ObjectAttribute;
 use CardTechie\TradingCardApiSdk\Resources\Player;
 use CardTechie\TradingCardApiSdk\Resources\Playerteam;
 use CardTechie\TradingCardApiSdk\Resources\Set;
@@ -119,5 +120,13 @@ class TradingCardApi
     public function year(): Year
     {
         return new Year($this->client);
+    }
+
+    /**
+     * Retrieve the object attribute resource.
+     */
+    public function objectAttribute(): ObjectAttribute
+    {
+        return new ObjectAttribute($this->client);
     }
 }

--- a/tests/Models/ObjectAttributeModelTest.php
+++ b/tests/Models/ObjectAttributeModelTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Models\Card;
+use CardTechie\TradingCardApiSdk\Models\ObjectAttribute;
+
+beforeEach(function () {
+    // Set up configuration
+    $this->app['config']->set('tradingcardapi', [
+        'url' => 'https://api.example.com',
+        'ssl_verify' => true,
+    ]);
+});
+
+it('can be instantiated with attributes', function () {
+    $attributes = [
+        'id' => '123',
+        'name' => 'Test Attribute',
+        'value' => 'Test Value',
+        'description' => 'A test object attribute description',
+    ];
+
+    $objectAttribute = new ObjectAttribute($attributes);
+
+    expect($objectAttribute->id)->toBe('123');
+    expect($objectAttribute->name)->toBe('Test Attribute');
+    expect($objectAttribute->value)->toBe('Test Value');
+    expect($objectAttribute->description)->toBe('A test object attribute description');
+});
+
+it('can be instantiated without attributes', function () {
+    $objectAttribute = new ObjectAttribute;
+
+    expect($objectAttribute)->toBeInstanceOf(ObjectAttribute::class);
+});
+
+it('returns empty array when no cards', function () {
+    $objectAttribute = new ObjectAttribute(['id' => '123', 'name' => 'Test Attribute']);
+
+    $cards = $objectAttribute->cards();
+
+    expect($cards)->toBe([]);
+});
+
+it('returns cards array when cards relationship exists', function () {
+    $objectAttribute = new ObjectAttribute(['id' => '123', 'name' => 'Test Attribute']);
+
+    $cardData = [
+        new Card(['id' => '1', 'name' => 'Card 1']),
+        new Card(['id' => '2', 'name' => 'Card 2']),
+    ];
+
+    $objectAttribute->setRelationships(['cards' => $cardData]);
+
+    $cards = $objectAttribute->cards();
+
+    expect($cards)->toHaveCount(2);
+    expect($cards[0])->toBeInstanceOf(Card::class);
+    expect($cards[0]->name)->toBe('Card 1');
+    expect($cards[1])->toBeInstanceOf(Card::class);
+    expect($cards[1]->name)->toBe('Card 2');
+});
+
+it('handles null attributes gracefully', function () {
+    $objectAttribute = new ObjectAttribute(['id' => '123', 'name' => null]);
+
+    expect($objectAttribute->id)->toBe('123');
+    expect($objectAttribute->name)->toBeNull();
+});
+
+it('magic get returns null for non-existent attributes', function () {
+    $objectAttribute = new ObjectAttribute(['id' => '123']);
+
+    expect($objectAttribute->nonExistentProperty)->toBeNull();
+});
+
+it('magic isset works correctly', function () {
+    $objectAttribute = new ObjectAttribute(['id' => '123', 'name' => 'Test Attribute']);
+
+    expect(isset($objectAttribute->id))->toBeTrue();
+    expect(isset($objectAttribute->name))->toBeTrue();
+    expect(isset($objectAttribute->nonExistentProperty))->toBeFalse();
+});
+
+it('converts to string correctly', function () {
+    $objectAttribute = new ObjectAttribute(['id' => '123', 'name' => 'Test Attribute']);
+
+    $jsonString = (string) $objectAttribute;
+    $decodedJson = json_decode($jsonString, true);
+
+    expect($decodedJson)->toHaveKey('id', '123');
+    expect($decodedJson)->toHaveKey('name', 'Test Attribute');
+});
+
+it('converts to string with relationships', function () {
+    $objectAttribute = new ObjectAttribute(['id' => '123', 'name' => 'Test Attribute']);
+
+    $cardData = [
+        new Card(['id' => '1', 'name' => 'Card 1']),
+    ];
+
+    $objectAttribute->setRelationships(['cards' => $cardData]);
+
+    $jsonString = (string) $objectAttribute;
+    $decodedJson = json_decode($jsonString, true);
+
+    expect($decodedJson)->toHaveKey('id', '123');
+    expect($decodedJson)->toHaveKey('name', 'Test Attribute');
+    expect($decodedJson)->toHaveKey('cards');
+    expect($decodedJson['cards'])->toBeArray();
+    expect($decodedJson['cards'])->toHaveCount(1);
+});

--- a/tests/Resources/ObjectAttributeResourceTest.php
+++ b/tests/Resources/ObjectAttributeResourceTest.php
@@ -1,0 +1,272 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Models\ObjectAttribute as ObjectAttributeModel;
+use CardTechie\TradingCardApiSdk\Resources\ObjectAttribute;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+beforeEach(function () {
+    // Set up configuration
+    $this->app['config']->set('tradingcardapi', [
+        'url' => 'https://api.example.com',
+        'ssl_verify' => true,
+        'client_id' => 'test-client-id',
+        'client_secret' => 'test-client-secret',
+    ]);
+
+    // Pre-populate cache with token to avoid OAuth requests
+    cache()->put('tcapi_token', 'test-token', 60);
+
+    $this->mockHandler = new MockHandler;
+    $handlerStack = HandlerStack::create($this->mockHandler);
+    $this->client = new Client(['handler' => $handlerStack]);
+    $this->objectAttributeResource = new ObjectAttribute($this->client);
+});
+
+it('can be instantiated with client', function () {
+    expect($this->objectAttributeResource)->toBeInstanceOf(ObjectAttribute::class);
+});
+
+it('can create an object attribute', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'objectAttributes',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Test Attribute',
+                    'value' => 'Test Value',
+                    'description' => 'A test object attribute',
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = [
+        'name' => 'Test Attribute',
+        'value' => 'Test Value',
+        'description' => 'A test object attribute',
+    ];
+
+    $result = $this->objectAttributeResource->create($attributes);
+
+    expect($result)->toBeInstanceOf(ObjectAttributeModel::class);
+});
+
+it('can create object attribute without attributes', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'objectAttributes',
+                'id' => '123',
+                'attributes' => [],
+            ],
+        ]))
+    );
+
+    $result = $this->objectAttributeResource->create();
+
+    expect($result)->toBeInstanceOf(ObjectAttributeModel::class);
+});
+
+it('can create an object attribute with relationships', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'objectAttributes',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Test Attribute',
+                ],
+                'relationships' => [
+                    'cards' => [
+                        'data' => [['type' => 'cards', 'id' => '456']],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = ['name' => 'Test Attribute'];
+    $relationships = [
+        'cards' => [
+            'data' => [['type' => 'cards', 'id' => '456']],
+        ],
+    ];
+
+    $result = $this->objectAttributeResource->create($attributes, $relationships);
+
+    expect($result)->toBeInstanceOf(ObjectAttributeModel::class);
+});
+
+it('can get an object attribute by id', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'objectAttributes',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Test Attribute',
+                    'value' => 'Test Value',
+                    'description' => 'A test object attribute',
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->objectAttributeResource->get('123');
+
+    expect($result)->toBeInstanceOf(ObjectAttributeModel::class);
+});
+
+it('can get an object attribute by id with custom params', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'objectAttributes',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Test Attribute',
+                    'value' => 'Test Value',
+                    'description' => 'A test object attribute',
+                ],
+            ],
+        ]))
+    );
+
+    $params = ['include' => 'cards'];
+    $result = $this->objectAttributeResource->get('123', $params);
+
+    expect($result)->toBeInstanceOf(ObjectAttributeModel::class);
+});
+
+it('can get a list of object attributes', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                [
+                    'type' => 'objectAttributes',
+                    'id' => '123',
+                    'attributes' => [
+                        'name' => 'Attribute 1',
+                    ],
+                ],
+                [
+                    'type' => 'objectAttributes',
+                    'id' => '124',
+                    'attributes' => [
+                        'name' => 'Attribute 2',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'total' => 100,
+                    'per_page' => 50,
+                    'current_page' => 1,
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->objectAttributeResource->list();
+
+    expect($result)->toBeInstanceOf(LengthAwarePaginator::class);
+});
+
+it('can get a list of object attributes with custom params', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                [
+                    'type' => 'objectAttributes',
+                    'id' => '123',
+                    'attributes' => [
+                        'name' => 'Attribute 1',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'total' => 100,
+                    'per_page' => 25,
+                    'current_page' => 2,
+                ],
+            ],
+        ]))
+    );
+
+    $params = ['limit' => 25, 'page' => 2];
+    $result = $this->objectAttributeResource->list($params);
+
+    expect($result)->toBeInstanceOf(LengthAwarePaginator::class);
+});
+
+it('can update an object attribute', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'objectAttributes',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Updated Attribute',
+                    'value' => 'Updated Value',
+                    'description' => 'Updated description',
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = [
+        'name' => 'Updated Attribute',
+        'value' => 'Updated Value',
+        'description' => 'Updated description',
+    ];
+
+    $result = $this->objectAttributeResource->update('123', $attributes);
+
+    expect($result)->toBeInstanceOf(ObjectAttributeModel::class);
+});
+
+it('can update an object attribute with relationships', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'objectAttributes',
+                'id' => '123',
+                'attributes' => [
+                    'name' => 'Updated Attribute',
+                ],
+                'relationships' => [
+                    'cards' => [
+                        'data' => [['type' => 'cards', 'id' => '789']],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $attributes = ['name' => 'Updated Attribute'];
+    $relationships = [
+        'cards' => [
+            'data' => [['type' => 'cards', 'id' => '789']],
+        ],
+    ];
+
+    $result = $this->objectAttributeResource->update('123', $attributes, $relationships);
+
+    expect($result)->toBeInstanceOf(ObjectAttributeModel::class);
+});
+
+it('can delete an object attribute', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(204, [], '')
+    );
+
+    $this->objectAttributeResource->delete('123');
+
+    expect(true)->toBeTrue(); // If no exception is thrown, the test passes
+});

--- a/tests/TradingCardApiTest.php
+++ b/tests/TradingCardApiTest.php
@@ -5,6 +5,7 @@ use CardTechie\TradingCardApiSdk\Resources\Brand;
 use CardTechie\TradingCardApiSdk\Resources\Card;
 use CardTechie\TradingCardApiSdk\Resources\Genre;
 use CardTechie\TradingCardApiSdk\Resources\Manufacturer;
+use CardTechie\TradingCardApiSdk\Resources\ObjectAttribute;
 use CardTechie\TradingCardApiSdk\Resources\Player;
 use CardTechie\TradingCardApiSdk\Resources\Playerteam;
 use CardTechie\TradingCardApiSdk\Resources\Set;
@@ -86,6 +87,12 @@ it('returns year resource', function () {
     $api = new TradingCardApi;
     $year = $api->year();
     expect($year)->toBeInstanceOf(Year::class);
+});
+
+it('returns object attribute resource', function () {
+    $api = new TradingCardApi;
+    $objectAttribute = $api->objectAttribute();
+    expect($objectAttribute)->toBeInstanceOf(ObjectAttribute::class);
 });
 
 it('creates guzzle client with correct configuration', function () {


### PR DESCRIPTION
## Summary
- ✅ Add ObjectAttribute resource class with full CRUD operations using `/v1/object-attributes` endpoints  
- ✅ Enhance ObjectAttribute model with `cards()` relationship method following SDK patterns
- ✅ Add `objectAttribute()` method to TradingCardApi class with proper imports
- ✅ Create comprehensive test coverage: 11 resource tests + 9 model tests + 1 API test
- ✅ Update README.md documentation to include ObjectAttributes in Available Resources table

## Test plan
- [x] All 214 tests pass (367 assertions) - no regressions introduced
- [x] ObjectAttribute resource tests cover all CRUD operations (create, get, list, update, delete)
- [x] ObjectAttribute model tests cover instantiation, relationships, and serialization  
- [x] TradingCardApi test verifies `objectAttribute()` method returns correct instance
- [x] Code formatted with Laravel Pint - 3 style issues fixed

🤖 Generated with [Claude Code](https://claude.ai/code)