### PR TITLE
#65 Add v1/stats endpoint to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The SDK provides access to the following Trading Card API resources:
 | **Manufacturers** | Trading card manufacturers | `get()`, `list()`, `create()`, `update()`, `delete()` |
 | **Years** | Trading card years | `get()`, `list()`, `create()`, `update()`, `delete()` |
 | **ObjectAttributes** | Object attributes | `get()`, `list()`, `create()`, `update()`, `delete()` |
+| **Stats** | Model statistics | `get($type)` |
 | **Attributes** | Card attributes | `get()`, `getList()` |
 
 ## 🔧 Configuration

--- a/src/Resources/Stats.php
+++ b/src/Resources/Stats.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CardTechie\TradingCardApiSdk\Resources;
+
+use CardTechie\TradingCardApiSdk\Resources\Traits\ApiRequest;
+use CardTechie\TradingCardApiSdk\Response;
+use GuzzleHttp\Client;
+
+class Stats
+{
+    use ApiRequest;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function get(string $type): \stdClass
+    {
+        $url = sprintf('/v1/stats/%s', $type);
+        $response = $this->makeRequest($url);
+
+        // Stats response doesn't have an ID field, so we handle it directly
+        return $response->data->attributes;
+    }
+}

--- a/src/TradingCardApi.php
+++ b/src/TradingCardApi.php
@@ -11,6 +11,7 @@ use CardTechie\TradingCardApiSdk\Resources\ObjectAttribute;
 use CardTechie\TradingCardApiSdk\Resources\Player;
 use CardTechie\TradingCardApiSdk\Resources\Playerteam;
 use CardTechie\TradingCardApiSdk\Resources\Set;
+use CardTechie\TradingCardApiSdk\Resources\Stats;
 use CardTechie\TradingCardApiSdk\Resources\Team;
 use CardTechie\TradingCardApiSdk\Resources\Year;
 use GuzzleHttp\Client;
@@ -128,5 +129,13 @@ class TradingCardApi
     public function objectAttribute(): ObjectAttribute
     {
         return new ObjectAttribute($this->client);
+    }
+
+    /**
+     * Retrieve the stats resource.
+     */
+    public function stats(): Stats
+    {
+        return new Stats($this->client);
     }
 }

--- a/tests/Resources/StatsResourceTest.php
+++ b/tests/Resources/StatsResourceTest.php
@@ -1,0 +1,235 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Resources\Stats;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+
+beforeEach(function () {
+    // Set up configuration
+    $this->app['config']->set('tradingcardapi', [
+        'url' => 'https://api.example.com',
+        'ssl_verify' => true,
+        'client_id' => 'test-client-id',
+        'client_secret' => 'test-client-secret',
+    ]);
+
+    // Pre-populate cache with token to avoid OAuth requests
+    cache()->put('tcapi_token', 'test-token', 60);
+
+    $this->mockHandler = new MockHandler;
+    $handlerStack = HandlerStack::create($this->mockHandler);
+    $this->client = new Client(['handler' => $handlerStack]);
+    $this->statsResource = new Stats($this->client);
+});
+
+it('can be instantiated with client', function () {
+    expect($this->statsResource)->toBeInstanceOf(Stats::class);
+});
+
+it('can get cards stats', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'stats',
+                'attributes' => [
+                    'model' => 'cards',
+                    'unit' => 'daily',
+                    'count' => 2,
+                    'stats' => [
+                        [
+                            'date' => '2024-01-15',
+                            'count' => 50,
+                            'total' => 50,
+                        ],
+                        [
+                            'date' => '2024-01-16',
+                            'count' => 100,
+                            'total' => 150,
+                        ],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->statsResource->get('cards');
+
+    expect($result)->toBeInstanceOf(\stdClass::class);
+    expect($result->model)->toBe('cards');
+    expect($result->unit)->toBe('daily');
+    expect($result->count)->toBe(2);
+    expect($result->stats)->toBeArray();
+    expect($result->stats)->toHaveCount(2);
+    expect($result->stats[0]->date)->toBe('2024-01-15');
+    expect($result->stats[0]->count)->toBe(50);
+    expect($result->stats[0]->total)->toBe(50);
+    expect($result->stats[1]->date)->toBe('2024-01-16');
+    expect($result->stats[1]->count)->toBe(100);
+    expect($result->stats[1]->total)->toBe(150);
+});
+
+it('can get sets stats', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'stats',
+                'attributes' => [
+                    'model' => 'sets',
+                    'unit' => 'daily',
+                    'count' => 1,
+                    'stats' => [
+                        [
+                            'date' => '2024-01-15',
+                            'count' => 25,
+                            'total' => 25,
+                        ],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->statsResource->get('sets');
+
+    expect($result)->toBeInstanceOf(\stdClass::class);
+    expect($result->model)->toBe('sets');
+    expect($result->unit)->toBe('daily');
+    expect($result->count)->toBe(1);
+    expect($result->stats)->toBeArray();
+    expect($result->stats)->toHaveCount(1);
+    expect($result->stats[0]->date)->toBe('2024-01-15');
+    expect($result->stats[0]->count)->toBe(25);
+    expect($result->stats[0]->total)->toBe(25);
+});
+
+it('can get players stats', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'stats',
+                'attributes' => [
+                    'model' => 'players',
+                    'unit' => 'daily',
+                    'count' => 3,
+                    'stats' => [
+                        [
+                            'date' => '2024-01-10',
+                            'count' => 10,
+                            'total' => 10,
+                        ],
+                        [
+                            'date' => '2024-01-11',
+                            'count' => 15,
+                            'total' => 25,
+                        ],
+                        [
+                            'date' => '2024-01-12',
+                            'count' => -5,
+                            'total' => 20,
+                        ],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->statsResource->get('players');
+
+    expect($result)->toBeInstanceOf(\stdClass::class);
+    expect($result->model)->toBe('players');
+    expect($result->unit)->toBe('daily');
+    expect($result->count)->toBe(3);
+    expect($result->stats)->toBeArray();
+    expect($result->stats)->toHaveCount(3);
+    expect($result->stats[2]->count)->toBe(-5); // Test negative count (deletions)
+    expect($result->stats[2]->total)->toBe(20);
+});
+
+it('can get teams stats', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'stats',
+                'attributes' => [
+                    'model' => 'teams',
+                    'unit' => 'daily',
+                    'count' => 1,
+                    'stats' => [
+                        [
+                            'date' => '2024-01-20',
+                            'count' => 5,
+                            'total' => 5,
+                        ],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->statsResource->get('teams');
+
+    expect($result)->toBeInstanceOf(\stdClass::class);
+    expect($result->model)->toBe('teams');
+    expect($result->count)->toBe(1);
+    expect($result->stats)->toHaveCount(1);
+});
+
+it('can get brands stats', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'stats',
+                'attributes' => [
+                    'model' => 'brands',
+                    'unit' => 'daily',
+                    'count' => 2,
+                    'stats' => [
+                        [
+                            'date' => '2024-01-18',
+                            'count' => 3,
+                            'total' => 3,
+                        ],
+                        [
+                            'date' => '2024-01-19',
+                            'count' => 7,
+                            'total' => 10,
+                        ],
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->statsResource->get('brands');
+
+    expect($result)->toBeInstanceOf(\stdClass::class);
+    expect($result->model)->toBe('brands');
+    expect($result->count)->toBe(2);
+    expect($result->stats)->toHaveCount(2);
+});
+
+it('handles empty stats response', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'type' => 'stats',
+                'attributes' => [
+                    'model' => 'manufacturers',
+                    'unit' => 'daily',
+                    'count' => 0,
+                    'stats' => [],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->statsResource->get('manufacturers');
+
+    expect($result)->toBeInstanceOf(\stdClass::class);
+    expect($result->model)->toBe('manufacturers');
+    expect($result->count)->toBe(0);
+    expect($result->stats)->toBeArray();
+    expect($result->stats)->toHaveCount(0);
+});

--- a/tests/TradingCardApiTest.php
+++ b/tests/TradingCardApiTest.php
@@ -9,6 +9,7 @@ use CardTechie\TradingCardApiSdk\Resources\ObjectAttribute;
 use CardTechie\TradingCardApiSdk\Resources\Player;
 use CardTechie\TradingCardApiSdk\Resources\Playerteam;
 use CardTechie\TradingCardApiSdk\Resources\Set;
+use CardTechie\TradingCardApiSdk\Resources\Stats;
 use CardTechie\TradingCardApiSdk\Resources\Team;
 use CardTechie\TradingCardApiSdk\Resources\Year;
 use CardTechie\TradingCardApiSdk\TradingCardApi;
@@ -93,6 +94,12 @@ it('returns object attribute resource', function () {
     $api = new TradingCardApi;
     $objectAttribute = $api->objectAttribute();
     expect($objectAttribute)->toBeInstanceOf(ObjectAttribute::class);
+});
+
+it('returns stats resource', function () {
+    $api = new TradingCardApi;
+    $stats = $api->stats();
+    expect($stats)->toBeInstanceOf(Stats::class);
 });
 
 it('creates guzzle client with correct configuration', function () {


### PR DESCRIPTION
## Summary
- ✅ Add Stats resource class with `get($type)` method using `/v1/stats/{type}` endpoints
- ✅ Add `stats()` method to TradingCardApi class with proper imports  
- ✅ Create comprehensive test coverage: 7 resource tests + 1 API test
- ✅ Handle stats response format directly since it lacks typical resource structure (no ID field)
- ✅ Support all model types: cards, sets, players, teams, brands, manufacturers, etc.
- ✅ Update README.md documentation to include Stats in Available Resources table

## API Endpoint Details
**Route**: `/v1/stats/{type}` (e.g., `/v1/stats/cards`, `/v1/stats/players`)  
**Returns**: Daily statistics with creation/deletion counts and running totals  
**Response Format**: JSON:API format with `data.type = 'stats'` and attributes containing model, unit, count, and stats array

## Test plan
- [x] All 223 tests pass (412 assertions) - no regressions introduced
- [x] Stats resource tests cover various model types (cards, sets, players, teams, brands)
- [x] Stats resource tests handle empty responses and negative counts (deletions)
- [x] TradingCardApi test verifies `stats()` method returns correct Stats instance
- [x] Code formatted with Laravel Pint - 2 style issues fixed

🤖 Generated with [Claude Code](https://claude.ai/code)