### PR TITLE
Fix Brand resource pagination when API response missing meta property (#115)

### DIFF
--- a/src/Resources/Brand.php
+++ b/src/Resources/Brand.php
@@ -88,9 +88,10 @@ class Brand
         $url = sprintf('/v1/brands?%s', http_build_query($params));
         $response = $this->makeRequest($url);
 
-        $totalPages = $response->meta->pagination->total;
-        $perPage = $response->meta->pagination->per_page;
-        $page = $response->meta->pagination->current_page;
+        // Handle missing meta information gracefully
+        $totalPages = isset($response->meta->pagination->total) ? $response->meta->pagination->total : count($response->data);
+        $perPage = isset($response->meta->pagination->per_page) ? $response->meta->pagination->per_page : ($params['limit'] ?? 50);
+        $page = isset($response->meta->pagination->current_page) ? $response->meta->pagination->current_page : ($params['page'] ?? 1);
         $options = [
             'path' => LengthAwarePaginator::resolveCurrentPath(),
             'pageName' => $params['pageName'],


### PR DESCRIPTION
## Summary
- Fix Brand resource pagination crash when API response lacks meta.pagination properties
- Add defensive handling with sensible fallbacks for missing pagination metadata
- Matches the fix previously applied to Team resource for consistency

## Changes Made
- **Brand::list() method**: Added isset() checks before accessing pagination properties
- **Fallback values**: Use count($response->data) for total, params for per_page/page
- **Comment**: Added explanatory comment matching Team resource pattern

## Error Fixed
```
Failed to get paginated brands: Undefined property: stdClass::$meta
```

## Testing
- ✅ All Brand resource tests pass (11 tests, 11 assertions)  
- ✅ All Brand-related tests pass (23 tests, 44 assertions)
- ✅ No breaking changes to existing functionality

## Before/After

**Before:**
```php
$totalPages = $response->meta->pagination->total;
$perPage = $response->meta->pagination->per_page;  
$page = $response->meta->pagination->current_page;
```

**After:**
```php
$totalPages = isset($response->meta->pagination->total) ? $response->meta->pagination->total : count($response->data);
$perPage = isset($response->meta->pagination->per_page) ? $response->meta->pagination->per_page : ($params['limit'] ?? 50);
$page = isset($response->meta->pagination->current_page) ? $response->meta->pagination->current_page : ($params['page'] ?? 1);
```

Resolves #115