### PR TITLE
Fix Manufacturer resource pagination bug (Issue #117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2025-09-28
+
+### Fixed
+- Manufacturer resource pagination crash when API response missing meta property
+- Added defensive handling for missing pagination metadata in Manufacturer::list() method
+- Added collection validation rules for Manufacturer schema to support array responses
+- Fixed ManufacturerSchema validation failing on collection endpoints
+
+### Added
+- ManufacturerSchema::getCollectionRules() method for proper collection response validation
+- Enhanced defensive pagination handling with multi-level isset() checks
+
 ## [0.1.7] - 2025-09-28
 
 ### Fixed

--- a/src/Resources/Manufacturer.php
+++ b/src/Resources/Manufacturer.php
@@ -89,9 +89,9 @@ class Manufacturer
         $response = $this->makeRequest($url);
 
         // Handle missing meta information gracefully
-        $totalPages = isset($response->meta->pagination->total) ? $response->meta->pagination->total : count($response->data);
-        $perPage = isset($response->meta->pagination->per_page) ? $response->meta->pagination->per_page : ($params['limit'] ?? 50);
-        $page = isset($response->meta->pagination->current_page) ? $response->meta->pagination->current_page : ($params['page'] ?? 1);
+        $totalPages = isset($response->meta, $response->meta->pagination, $response->meta->pagination->total) ? $response->meta->pagination->total : count($response->data);
+        $perPage = isset($response->meta, $response->meta->pagination, $response->meta->pagination->per_page) ? $response->meta->pagination->per_page : ($params['limit'] ?? 50);
+        $page = isset($response->meta, $response->meta->pagination, $response->meta->pagination->current_page) ? $response->meta->pagination->current_page : ($params['page'] ?? 1);
         $options = [
             'path' => LengthAwarePaginator::resolveCurrentPath(),
             'pageName' => $params['pageName'],

--- a/src/Resources/Manufacturer.php
+++ b/src/Resources/Manufacturer.php
@@ -88,9 +88,10 @@ class Manufacturer
         $url = sprintf('/v1/manufacturers?%s', http_build_query($params));
         $response = $this->makeRequest($url);
 
-        $totalPages = $response->meta->pagination->total;
-        $perPage = $response->meta->pagination->per_page;
-        $page = $response->meta->pagination->current_page;
+        // Handle missing meta information gracefully
+        $totalPages = isset($response->meta->pagination->total) ? $response->meta->pagination->total : count($response->data);
+        $perPage = isset($response->meta->pagination->per_page) ? $response->meta->pagination->per_page : ($params['limit'] ?? 50);
+        $page = isset($response->meta->pagination->current_page) ? $response->meta->pagination->current_page : ($params['page'] ?? 1);
         $options = [
             'path' => LengthAwarePaginator::resolveCurrentPath(),
             'pageName' => $params['pageName'],

--- a/src/Schemas/ManufacturerSchema.php
+++ b/src/Schemas/ManufacturerSchema.php
@@ -20,6 +20,18 @@ class ManufacturerSchema extends BaseSchema
     }
 
     /**
+     * Get validation rules for Manufacturer collection responses
+     */
+    public function getCollectionRules(): array
+    {
+        return $this->mergeRules(
+            $this->getJsonApiCollectionRules(),
+            $this->getMetaLinksRules(),
+            $this->getManufacturerCollectionSpecificRules()
+        );
+    }
+
+    /**
      * Get Manufacturer-specific validation rules
      */
     private function getManufacturerSpecificRules(): array
@@ -35,6 +47,25 @@ class ManufacturerSchema extends BaseSchema
             'data.attributes.is_active' => 'sometimes|boolean|nullable',
             'data.attributes.created_at' => 'sometimes|string|nullable',
             'data.attributes.updated_at' => 'sometimes|string|nullable',
+        ];
+    }
+
+    /**
+     * Get Manufacturer-specific validation rules for collections
+     */
+    private function getManufacturerCollectionSpecificRules(): array
+    {
+        return [
+            'data.*.type' => 'sometimes|required|string|in:manufacturers,manufacturer',
+            'data.*.attributes.name' => 'sometimes|string|nullable',
+            'data.*.attributes.description' => 'sometimes|string|nullable',
+            'data.*.attributes.website' => 'sometimes|string|nullable',
+            'data.*.attributes.founded' => 'sometimes|integer|nullable',
+            'data.*.attributes.headquarters' => 'sometimes|string|nullable',
+            'data.*.attributes.country' => 'sometimes|string|nullable',
+            'data.*.attributes.is_active' => 'sometimes|boolean|nullable',
+            'data.*.attributes.created_at' => 'sometimes|string|nullable',
+            'data.*.attributes.updated_at' => 'sometimes|string|nullable',
         ];
     }
 }


### PR DESCRIPTION
## Summary
- Adds defensive handling for missing meta.pagination properties in Manufacturer resource
- Prevents "Undefined property: stdClass::$meta" errors
- Uses fallback values when pagination meta is missing

## Test plan
- [ ] Test Manufacturer listing with and without pagination meta
- [ ] Verify pagination still works correctly with complete API responses
- [ ] Confirm no errors when meta properties are missing

🤖 Generated with [Claude Code](https://claude.ai/code)