### PR TITLE
Document v2 API Endpoint Availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **API Versions Documentation** - Added comprehensive documentation explaining v1 and v2 endpoint differences
+  - New "API Versions" section in README.md
+  - Explains v1 endpoints (relationship-focused, SDK default)
+  - Explains v2 endpoints (stricter JSON:API compliance)
+  - Includes JSON response examples for both versions
+  - Notes SDK's current v1-only support with future v2 consideration
+
 - **Card Images API Support** - Complete implementation of Card Images functionality (Trading Card API v0.7.0)
   - New `CardImage` model with properties for image metadata and relationships
   - New `CardImage` resource class with full CRUD operations

--- a/README.md
+++ b/README.md
@@ -494,6 +494,83 @@ return [
 ];
 ```
 
+## 🔄 API Versions
+
+The Trading Card API provides both v1 and v2 endpoints with different response structures to support various JSON:API compliance levels.
+
+### v1 Endpoints (Default)
+
+**The SDK uses v1 endpoints by default.** These endpoints follow a relationship-focused JSON:API pattern where related resources are returned in the `included` array alongside the primary resource.
+
+**Example:** `GET /v1/sets/{id}/checklist`
+
+```json
+{
+  "data": {
+    "type": "sets",
+    "id": "set-uuid",
+    "attributes": {
+      "name": "1989 Topps Baseball"
+    }
+  },
+  "included": [
+    {
+      "type": "cards",
+      "id": "card-1",
+      "attributes": { "number": "1", "name": "Player 1" }
+    },
+    {
+      "type": "cards",
+      "id": "card-2",
+      "attributes": { "number": "2", "name": "Player 2" }
+    }
+  ]
+}
+```
+
+**Characteristics:**
+- Primary resource in `data` object
+- Related resources in `included` array
+- Follows JSON:API relationship pattern
+- Optimal for accessing both the parent resource and related data
+
+### v2 Endpoints (Stricter JSON:API Compliance)
+
+The API also provides v2 endpoints with stricter JSON:API compliance. These endpoints return collections as the primary `data` array when accessing relationship endpoints.
+
+**Example:** `GET /v2/sets/{id}/checklist`
+
+```json
+{
+  "data": [
+    {
+      "type": "cards",
+      "id": "card-1",
+      "attributes": { "number": "1", "name": "Player 1" }
+    },
+    {
+      "type": "cards",
+      "id": "card-2",
+      "attributes": { "number": "2", "name": "Player 2" }
+    }
+  ]
+}
+```
+
+**Characteristics:**
+- Collection resources in `data` array
+- More JSON:API compliant for collection endpoints
+- Focuses on the requested collection rather than parent resource
+- Cleaner structure when you only need the related resources
+
+### Version Support
+
+**Current SDK Support:** v1 endpoints only
+
+**Future Plans:** v2 endpoint support may be added in a future SDK version based on user feedback and demand. Both versions return the same data, just structured differently according to JSON:API specifications.
+
+**Need v2 Support?** If you require v2 endpoint support, please [open an issue](https://github.com/cardtechie/tradingcardapi-sdk-php/issues) describing your use case.
+
 ## 🧪 Development & Testing
 
 This project uses modern PHP development tools and practices:


### PR DESCRIPTION
## Summary

Adds comprehensive documentation explaining the differences between Trading Card API v1 and v2 endpoints.

## Changes

- **Added "API Versions" section to README.md**
  - Explains v1 endpoints (relationship-focused, SDK default)
  - Explains v2 endpoints (stricter JSON:API compliance)
  - Includes JSON response examples showing structural differences
  - Notes SDK's current v1-only support
  - Provides call-to-action for users needing v2 support

- **Updated CHANGELOG.md**
  - Documented new API Versions documentation in [Unreleased] section

## Documentation Preview

The new section explains:

### v1 Endpoints (Default)
- Primary resource in `data` object
- Related resources in `included` array
- Follows JSON:API relationship pattern
- Example: `GET /v1/sets/{id}/checklist` returns set with cards in included array

### v2 Endpoints
- Collection resources in `data` array
- More JSON:API compliant for collection endpoints
- Example: `GET /v2/sets/{id}/checklist` returns cards as primary data array

## Testing

- ✅ `make format` - All 125 files passed
- ✅ Documentation-only changes (no code modifications)
- ✅ Markdown formatting verified

## Closes

Closes #128

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)