### PR TITLE
fix: Cherry-pick Content-Type header fix for POST/PUT/PATCH requests (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Content-Type Header for Mutating Requests** - Fixed JSON:API Content-Type header for POST/PUT/PATCH requests
+  - Changed `ApiRequest` trait to send `Content-Type: application/vnd.api+json` for mutating requests (POST, PUT, PATCH)
+  - Previously sent `application/json` causing 415 Unsupported Media Type errors
+  - GET and DELETE requests no longer send Content-Type header (not needed for requests without body)
+  - Custom Content-Type headers can still override the default if needed
+  - Fixes issue #139 - Resolves admin application Dusk test failures
+
 ## [0.1.10] - 2025-10-30
 
 ### Added
@@ -49,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Year Resource Pagination Crash** - Added defensive handling for missing meta property
-  - Fixed division by zero error when API response lacks pagination metadata  
+  - Fixed division by zero error when API response lacks pagination metadata
   - Added fallback pagination values using request params and response data
   - Applied consistent pagination handling matching other SDK resources
 - Year resource integration gaps preventing admin interface migration
@@ -111,7 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `TradingCardApiSdk::player()->get($id)` - Get player by ID
   - `TradingCardApiSdk::player()->list($params)` - List players with pagination
   - `TradingCardApiSdk::player()->create($data)` - Create new players
-  - `TradingCardApiSdk::player()->update($id, $data)` - Update existing players  
+  - `TradingCardApiSdk::player()->update($id, $data)` - Update existing players
   - `TradingCardApiSdk::player()->delete($id)` - Delete players
   - `TradingCardApiSdk::player()->listDeleted()` - List deleted players
   - `TradingCardApiSdk::player()->deleted($id)` - Get deleted player by ID
@@ -188,7 +197,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test matrix compatibility issues with Laravel 11+ and prefer-lowest strategy
 - PHPStan static analysis errors in ErrorResponseParser
 
-[Unreleased]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.10...HEAD
+[0.1.10]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/cardtechie/tradingcardapi-sdk-php/releases/tag/v0.1.0

--- a/src/Resources/Traits/ApiRequest.php
+++ b/src/Resources/Traits/ApiRequest.php
@@ -55,12 +55,20 @@ trait ApiRequest
     {
         $this->retrieveToken();
 
+        $isMultipart = isset($request['multipart']);
+
         $defaultRequest = [];
         $defaultHeaders = [
             'Accept' => 'application/json',
             'Authorization' => 'Bearer '.$this->token,
             'X-TCAPI-Ignore-Status' => (string) config('tradingcardapi.ignore_status', 0),
         ];
+
+        // For multipart requests, Guzzle will set Content-Type automatically
+        // For JSON:API requests (POST/PUT/PATCH), we need to set the JSON:API Content-Type
+        if (! $isMultipart && in_array(strtoupper($method), ['POST', 'PUT', 'PATCH'])) {
+            $defaultHeaders['Content-Type'] = 'application/vnd.api+json';
+        }
 
         $theRequest = array_merge($defaultRequest, $request);
         $theRequest['headers'] = array_merge($defaultHeaders, $headers);

--- a/tests/Traits/ApiRequestTest.php
+++ b/tests/Traits/ApiRequestTest.php
@@ -244,3 +244,187 @@ it('handles empty scope configuration', function () {
 
     expect($result)->toBeObject();
 });
+
+it('sets Content-Type header to application/vnd.api+json for POST requests', function () {
+    $client = m::mock(Client::class);
+
+    // Mock the OAuth token request
+    $tokenResponse = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'test-token',
+        'token_type' => 'Bearer',
+    ]));
+
+    // Mock the API request and verify Content-Type header
+    $apiResponse = new GuzzleResponse(201, [], json_encode(['data' => ['id' => '123']]));
+
+    $client->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::type('array'))
+        ->once()
+        ->andReturn($tokenResponse);
+
+    $client->shouldReceive('request')
+        ->with('POST', '/v1/cards', m::on(function ($request) {
+            return isset($request['headers']['Content-Type']) &&
+                   $request['headers']['Content-Type'] === 'application/vnd.api+json';
+        }))
+        ->once()
+        ->andReturn($apiResponse);
+
+    $instance = new TestApiRequestClass($client);
+    $result = $instance->testMakeRequest('/v1/cards', 'POST');
+
+    expect($result)->toBeObject();
+});
+
+it('sets Content-Type header to application/vnd.api+json for PUT requests', function () {
+    $client = m::mock(Client::class);
+
+    // Mock the OAuth token request
+    $tokenResponse = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'test-token',
+        'token_type' => 'Bearer',
+    ]));
+
+    // Mock the API request and verify Content-Type header
+    $apiResponse = new GuzzleResponse(200, [], json_encode(['data' => ['id' => '123']]));
+
+    $client->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::type('array'))
+        ->once()
+        ->andReturn($tokenResponse);
+
+    $client->shouldReceive('request')
+        ->with('PUT', '/v1/cards/123', m::on(function ($request) {
+            return isset($request['headers']['Content-Type']) &&
+                   $request['headers']['Content-Type'] === 'application/vnd.api+json';
+        }))
+        ->once()
+        ->andReturn($apiResponse);
+
+    $instance = new TestApiRequestClass($client);
+    $result = $instance->testMakeRequest('/v1/cards/123', 'PUT');
+
+    expect($result)->toBeObject();
+});
+
+it('sets Content-Type header to application/vnd.api+json for PATCH requests', function () {
+    $client = m::mock(Client::class);
+
+    // Mock the OAuth token request
+    $tokenResponse = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'test-token',
+        'token_type' => 'Bearer',
+    ]));
+
+    // Mock the API request and verify Content-Type header
+    $apiResponse = new GuzzleResponse(200, [], json_encode(['data' => ['id' => '123']]));
+
+    $client->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::type('array'))
+        ->once()
+        ->andReturn($tokenResponse);
+
+    $client->shouldReceive('request')
+        ->with('PATCH', '/v1/cards/123', m::on(function ($request) {
+            return isset($request['headers']['Content-Type']) &&
+                   $request['headers']['Content-Type'] === 'application/vnd.api+json';
+        }))
+        ->once()
+        ->andReturn($apiResponse);
+
+    $instance = new TestApiRequestClass($client);
+    $result = $instance->testMakeRequest('/v1/cards/123', 'PATCH');
+
+    expect($result)->toBeObject();
+});
+
+it('does not set Content-Type header for GET requests', function () {
+    $client = m::mock(Client::class);
+
+    // Mock the OAuth token request
+    $tokenResponse = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'test-token',
+        'token_type' => 'Bearer',
+    ]));
+
+    // Mock the API request and verify no Content-Type header
+    $apiResponse = new GuzzleResponse(200, [], json_encode(['data' => ['id' => '123']]));
+
+    $client->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::type('array'))
+        ->once()
+        ->andReturn($tokenResponse);
+
+    $client->shouldReceive('request')
+        ->with('GET', '/v1/cards/123', m::on(function ($request) {
+            return ! isset($request['headers']['Content-Type']);
+        }))
+        ->once()
+        ->andReturn($apiResponse);
+
+    $instance = new TestApiRequestClass($client);
+    $result = $instance->testMakeRequest('/v1/cards/123', 'GET');
+
+    expect($result)->toBeObject();
+});
+
+it('does not set Content-Type header for DELETE requests', function () {
+    $client = m::mock(Client::class);
+
+    // Mock the OAuth token request
+    $tokenResponse = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'test-token',
+        'token_type' => 'Bearer',
+    ]));
+
+    // Mock the API request and verify no Content-Type header
+    $apiResponse = new GuzzleResponse(204, [], '');
+
+    $client->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::type('array'))
+        ->once()
+        ->andReturn($tokenResponse);
+
+    $client->shouldReceive('request')
+        ->with('DELETE', '/v1/cards/123', m::on(function ($request) {
+            return ! isset($request['headers']['Content-Type']);
+        }))
+        ->once()
+        ->andReturn($apiResponse);
+
+    $instance = new TestApiRequestClass($client);
+    $result = $instance->testMakeRequest('/v1/cards/123', 'DELETE');
+
+    expect($result)->toBeInstanceOf(stdClass::class);
+});
+
+it('allows custom Content-Type header to override default for POST requests', function () {
+    $client = m::mock(Client::class);
+
+    // Mock the OAuth token request
+    $tokenResponse = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'test-token',
+        'token_type' => 'Bearer',
+    ]));
+
+    // Mock the API request with custom Content-Type
+    $apiResponse = new GuzzleResponse(200, [], json_encode(['success' => true]));
+
+    $client->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::type('array'))
+        ->once()
+        ->andReturn($tokenResponse);
+
+    $client->shouldReceive('request')
+        ->with('POST', '/test', m::on(function ($request) {
+            return isset($request['headers']['Content-Type']) &&
+                   $request['headers']['Content-Type'] === 'application/custom';
+        }))
+        ->once()
+        ->andReturn($apiResponse);
+
+    $instance = new TestApiRequestClass($client);
+    $result = $instance->testMakeRequest('/test', 'POST', [], ['Content-Type' => 'application/custom']);
+
+    expect($result->success)->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Cherry-picks the Content-Type header fix from commit d8dcbc2 (Issue #139, PR #140) to release as v0.1.11.

The fix was merged to `develop` but never released - v0.1.10 was tagged from `main` before the fix was applied.

**Changes:**
- SDK now sends `Content-Type: application/vnd.api+json` for POST/PUT/PATCH requests
- Previously sent no Content-Type header, causing 415 Unsupported Media Type errors
- GET and DELETE requests do not send Content-Type header (not needed)
- Custom Content-Type headers can still override the default

Closes #142 (duplicate of #139)

## Test Plan

- [x] All 44 unit tests pass (including 6 new Content-Type tests)
- [x] Tests verify POST/PUT/PATCH send correct header
- [x] Tests verify GET/DELETE do not send Content-Type header
- [x] Tests verify custom Content-Type can override default

🤖 Generated with [Claude Code](https://claude.com/claude-code)