### PR TITLE
feat: Add OnCardable trait to Player and Team models

### DIFF
--- a/src/Models/Player.php
+++ b/src/Models/Player.php
@@ -3,6 +3,8 @@
 namespace CardTechie\TradingCardApiSdk\Models;
 
 use CardTechie\TradingCardApiSdk\Facades\TradingCardApiSdk;
+use CardTechie\TradingCardApiSdk\Models\Traits\OnCardable;
+use CardTechie\TradingCardApiSdk\Utils\StringHelpers;
 use Illuminate\Support\Collection;
 
 /**
@@ -15,6 +17,46 @@ use Illuminate\Support\Collection;
  */
 class Player extends Model implements Taxonomy
 {
+    use OnCardable;
+
+    /**
+     * Return the onCardable configuration array for this model.
+     */
+    public function onCardable(): array
+    {
+        return [
+            'name' => 'Player',
+        ];
+    }
+
+    /**
+     * Prepare the on card relationships and return the object that matches the passed in data.
+     *
+     * @param  array<string, mixed>  $data  Array containing 'player' key with UUID or name
+     * @return Player|null
+     */
+    public static function prepare($data): ?object
+    {
+        if (empty($data['player'])) {
+            return null;
+        }
+
+        /** @var string $playerValue */
+        $playerValue = $data['player'];
+
+        // If it's a UUID, validate and return a player instance
+        if (StringHelpers::isValidUuid($playerValue)) {
+            try {
+                return TradingCardApiSdk::player()->get($playerValue);
+            } catch (\Exception $e) {
+                throw new \InvalidArgumentException("Player with UUID {$playerValue} not found");
+            }
+        }
+
+        // It's a name, look up or create the player
+        return self::getFromApi(['player' => $playerValue]);
+    }
+
     /**
      * Return the full name of the player
      */

--- a/src/Models/Team.php
+++ b/src/Models/Team.php
@@ -3,6 +3,8 @@
 namespace CardTechie\TradingCardApiSdk\Models;
 
 use CardTechie\TradingCardApiSdk\Facades\TradingCardApiSdk;
+use CardTechie\TradingCardApiSdk\Models\Traits\OnCardable;
+use CardTechie\TradingCardApiSdk\Utils\StringHelpers;
 
 /**
  * Class Team
@@ -12,6 +14,46 @@ use CardTechie\TradingCardApiSdk\Facades\TradingCardApiSdk;
  */
 class Team extends Model implements Taxonomy
 {
+    use OnCardable;
+
+    /**
+     * Return the onCardable configuration array for this model.
+     */
+    public function onCardable(): array
+    {
+        return [
+            'name' => 'Team',
+        ];
+    }
+
+    /**
+     * Prepare the on card relationships and return the object that matches the passed in data.
+     *
+     * @param  array<string, mixed>  $data  Array containing 'team' key with UUID or name
+     * @return Team|null
+     */
+    public static function prepare($data): ?object
+    {
+        if (empty($data['team'])) {
+            return null;
+        }
+
+        /** @var string $teamValue */
+        $teamValue = $data['team'];
+
+        // If it's a UUID, validate and return a team instance
+        if (StringHelpers::isValidUuid($teamValue)) {
+            try {
+                return TradingCardApiSdk::team()->get($teamValue);
+            } catch (\Exception $e) {
+                throw new \InvalidArgumentException("Team with UUID {$teamValue} not found");
+            }
+        }
+
+        // It's a name, look up or create the team
+        return self::getFromApi(['team' => $teamValue]);
+    }
+
     /**
      * Get the full name of the team
      */


### PR DESCRIPTION
## Summary
- Added `OnCardable` trait to `Player` and `Team` models
- Implemented `onCardable()` configuration method for each model
- Implemented `prepare()` static method for handling form data with UUID or name lookups
- Enables independent Player and Team oncard relationships (not just through Playerteam)

This allows SDK consumers to register Player and Team as separate oncardable types, enabling cards to have direct player-only or team-only associations without requiring a Playerteam relationship.

## Test plan
- [x] All existing tests pass
- [x] PHPStan static analysis passes
- [x] Laravel Pint code style passes

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)