### PR TITLE
fix: correct SetSource JSON:API type from 'set-sources' to 'set_sources' (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16] - 2026-01-03
+
 ### Fixed
 
 - **SetSource JSON:API type correction** - Fixed request type from `set-sources` to `set_sources` to match API expectations (Issue #158)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,7 +259,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test matrix compatibility issues with Laravel 11+ and prefer-lowest strategy
 - PHPStan static analysis errors in ErrorResponseParser
 
-[Unreleased]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.15...HEAD
+[Unreleased]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.16...HEAD
+[0.1.16]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.15...0.1.16
 [0.1.15]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.14...0.1.15
 [0.1.14]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.13...0.1.14
 [0.1.13]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.12...0.1.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SetSource JSON:API type correction** - Fixed request type from `set-sources` to `set_sources` to match API expectations (Issue #158)
+
 ## [0.1.15] - 2025-12-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **SetSource JSON:API type correction** - Fixed request type from `set-sources` to `set_sources` to match API expectations (Issue #158)
 
+## [0.1.16] - 2026-01-02
+
+### Fixed
+
+- **Subsets type handling** - Fixed Response class to handle plural `subsets` type from API responses, preventing "Unknown model type" errors on subsets view
+
 ## [0.1.15] - 2025-12-31
 
 ### Added
@@ -260,7 +266,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPStan static analysis errors in ErrorResponseParser
 
 [Unreleased]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.17...HEAD
-[0.1.17]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.15...0.1.17
+[0.1.17]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.16...0.1.17
+[0.1.16]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.15...0.1.16
 [0.1.15]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.14...0.1.15
 [0.1.14]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.13...0.1.14
 [0.1.13]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.12...0.1.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.16] - 2026-01-03
+## [0.1.17] - 2026-01-03
 
 ### Fixed
 
@@ -259,8 +259,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test matrix compatibility issues with Laravel 11+ and prefer-lowest strategy
 - PHPStan static analysis errors in ErrorResponseParser
 
-[Unreleased]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.16...HEAD
-[0.1.16]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.15...0.1.16
+[Unreleased]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.17...HEAD
+[0.1.17]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.15...0.1.17
 [0.1.15]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.14...0.1.15
 [0.1.14]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.13...0.1.14
 [0.1.13]: https://github.com/cardtechie/tradingcardapi-sdk-php/compare/0.1.12...0.1.13

--- a/src/Resources/SetSource.php
+++ b/src/Resources/SetSource.php
@@ -35,7 +35,7 @@ class SetSource
         $request = [
             'json' => [
                 'data' => [
-                    'type' => 'set-sources',
+                    'type' => 'set_sources',
                 ],
             ],
         ];
@@ -114,7 +114,7 @@ class SetSource
         $request = [
             'json' => [
                 'data' => [
-                    'type' => 'set-sources',
+                    'type' => 'set_sources',
                     'id' => $id,
                 ],
             ],


### PR DESCRIPTION
## Summary

Fixes the JSON:API type in SetSource resource requests from hyphenated format (`set-sources`) to underscored format (`set_sources`) which the API expects.

## Changes

- `src/Resources/SetSource.php` - Changed `'type' => 'set-sources'` to `'type' => 'set_sources'` on lines 38 and 117
- `tests/Resources/SetSourceResourceTest.php` - Added 2 tests to verify correct type is sent in request payloads
- `CHANGELOG.md` - Added fix entry for v0.1.17

## Root Cause

The Trading Card API consistently uses underscores for multi-word JSON:API types (e.g., `set_sources`, `sync_parallel`). The SetSource resource was incorrectly using hyphenated format, causing 422 validation errors.

## Testing

- [x] All tests pass (550 tests, 1404 assertions)
- [x] Lint passes (PHPStan Level 4)
- [x] Build passes
- [x] Security review completed
- [x] Performance review completed
- [x] Test coverage review completed
- [x] Copilot comments resolved

Closes #158

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)