### PR TITLE
feat: Add ConflictException for HTTP 409 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ConflictException` for HTTP 409 responses with `duplicate()` factory method
+
 ## [0.1.17] - 2026-01-03
 
 ### Fixed

--- a/src/Exceptions/ConflictException.php
+++ b/src/Exceptions/ConflictException.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace CardTechie\TradingCardApiSdk\Exceptions;
+
+/**
+ * Exception thrown when a conflict is detected (409 Conflict)
+ */
+class ConflictException extends TradingCardApiException
+{
+    /**
+     * Constructor
+     *
+     * @param  string  $message  The exception message
+     * @param  int  $code  The exception code
+     * @param  \Exception|null  $previous  The previous exception
+     * @param  string|null  $apiErrorCode  The API error code
+     * @param  array  $apiErrors  The API errors array
+     * @param  array  $context  Additional context for debugging
+     */
+    public function __construct(
+        string $message = 'Conflict detected',
+        int $code = 409,
+        ?\Exception $previous = null,
+        ?string $apiErrorCode = null,
+        array $apiErrors = [],
+        array $context = []
+    ) {
+        parent::__construct(
+            $message,
+            $code,
+            $previous,
+            $apiErrorCode,
+            $apiErrors,
+            409,
+            $context
+        );
+    }
+
+    /**
+     * Create exception for duplicate resource
+     */
+    public static function duplicate(string $resource = '', array $context = []): self
+    {
+        $message = $resource
+            ? "Duplicate {$resource} detected"
+            : 'Duplicate resource detected';
+
+        return new self(
+            $message,
+            409,
+            null,
+            'duplicate_resource',
+            [['title' => 'Conflict', 'detail' => $message]],
+            $context
+        );
+    }
+}

--- a/src/Services/ErrorResponseParser.php
+++ b/src/Services/ErrorResponseParser.php
@@ -4,6 +4,7 @@ namespace CardTechie\TradingCardApiSdk\Services;
 
 use CardTechie\TradingCardApiSdk\Exceptions\AuthenticationException;
 use CardTechie\TradingCardApiSdk\Exceptions\AuthorizationException;
+use CardTechie\TradingCardApiSdk\Exceptions\ConflictException;
 use CardTechie\TradingCardApiSdk\Exceptions\NetworkException;
 use CardTechie\TradingCardApiSdk\Exceptions\RateLimitException;
 use CardTechie\TradingCardApiSdk\Exceptions\ResourceNotFoundException;
@@ -127,6 +128,16 @@ class ErrorResponseParser
                 return new ValidationException(
                     $message,
                     422,
+                    $previous,
+                    $apiErrorCode,
+                    $apiErrors,
+                    $context
+                );
+
+            case 409:
+                return new ConflictException(
+                    $message,
+                    409,
                     $previous,
                     $apiErrorCode,
                     $apiErrors,
@@ -262,6 +273,7 @@ class ErrorResponseParser
             401 => 'Authentication failed',
             403 => 'Access forbidden',
             404 => 'Resource not found',
+            409 => 'Conflict detected',
             422 => 'Validation failed',
             429 => 'Rate limit exceeded',
             500 => 'Internal server error',

--- a/tests/Exceptions/ConflictExceptionTest.php
+++ b/tests/Exceptions/ConflictExceptionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Exceptions\ConflictException;
+
+it('creates conflict exception with default values', function () {
+    $exception = new ConflictException;
+
+    expect($exception->getMessage())->toBe('Conflict detected');
+    expect($exception->getCode())->toBe(409);
+    expect($exception->getHttpStatusCode())->toBe(409);
+});
+
+it('creates conflict exception with custom message', function () {
+    $exception = new ConflictException('Custom conflict message');
+
+    expect($exception->getMessage())->toBe('Custom conflict message');
+    expect($exception->getHttpStatusCode())->toBe(409);
+});
+
+it('creates duplicate resource exception', function () {
+    $exception = ConflictException::duplicate('card', ['card_id' => '123']);
+
+    expect($exception->getMessage())->toBe('Duplicate card detected');
+    expect($exception->getApiErrorCode())->toBe('duplicate_resource');
+    expect($exception->getApiErrors())->toHaveCount(1);
+    expect($exception->getApiErrors()[0]['title'])->toBe('Conflict');
+    expect($exception->getContext())->toBe(['card_id' => '123']);
+});
+
+it('creates duplicate resource exception without resource type', function () {
+    $exception = ConflictException::duplicate('', ['id' => '456']);
+
+    expect($exception->getMessage())->toBe('Duplicate resource detected');
+    expect($exception->getApiErrorCode())->toBe('duplicate_resource');
+    expect($exception->getContext())->toBe(['id' => '456']);
+});
+
+it('has correct HTTP status code', function () {
+    $exception = new ConflictException;
+    expect($exception->isClientError())->toBeTrue();
+    expect($exception->isServerError())->toBeFalse();
+});

--- a/tests/Services/ErrorResponseParserTest.php
+++ b/tests/Services/ErrorResponseParserTest.php
@@ -3,6 +3,7 @@
 use CardTechie\TradingCardApiSdk\Exceptions\AuthenticationException;
 use CardTechie\TradingCardApiSdk\Exceptions\AuthorizationException;
 use CardTechie\TradingCardApiSdk\Exceptions\CardNotFoundException;
+use CardTechie\TradingCardApiSdk\Exceptions\ConflictException;
 use CardTechie\TradingCardApiSdk\Exceptions\NetworkException;
 use CardTechie\TradingCardApiSdk\Exceptions\RateLimitException;
 use CardTechie\TradingCardApiSdk\Exceptions\ResourceNotFoundException;
@@ -57,6 +58,20 @@ it('parses 403 response as authorization exception', function () {
     expect($exception)->toBeInstanceOf(AuthorizationException::class);
     expect($exception->getMessage())->toBe('Access forbidden');
     expect($exception->getHttpStatusCode())->toBe(403);
+});
+
+it('parses 409 response as conflict exception', function () {
+    $response = new Response(409, [], json_encode([
+        'message' => 'Resource already exists',
+    ]));
+    $request = new Request('POST', '/api/cards');
+    $guzzleException = new ClientException('409 Conflict', $request, $response);
+
+    $exception = $this->parser->parseGuzzleException($guzzleException);
+
+    expect($exception)->toBeInstanceOf(ConflictException::class);
+    expect($exception->getMessage())->toBe('Resource already exists');
+    expect($exception->getHttpStatusCode())->toBe(409);
 });
 
 it('parses 404 response as resource not found exception', function () {


### PR DESCRIPTION
## Summary

- Adds `ConflictException` class for proper handling of HTTP 409 Conflict responses
- Updates `ErrorResponseParser` to return `ConflictException` for 409 status codes
- Includes `duplicate()` factory method for common duplicate resource scenarios

## Test plan

- [x] Run `make test` - all 554 tests pass
- [x] Run `make analyse` - PHPStan passes with no errors
- [x] Run `make check` - all quality checks pass
- [ ] Verify 409 responses from API return ConflictException

Closes #162

🤖 Generated with [Claude Code](https://claude.ai/claude-code)