### PR TITLE
feat: Add Workflow resource with actionableSets() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Workflow` resource with `actionableSets()` method for `GET /v1/workflow/actionable-sets` endpoint (#167)
 - `workflow()` method to `Set` resource for `GET /v1/sets/{id}/workflow` endpoint (#166)
 
 ## [0.1.18] - 2026-01-22

--- a/src/Resources/Workflow.php
+++ b/src/Resources/Workflow.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CardTechie\TradingCardApiSdk\Resources;
+
+use CardTechie\TradingCardApiSdk\Resources\Traits\ApiRequest;
+use GuzzleHttp\Client;
+
+class Workflow
+{
+    use ApiRequest;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Get the actionable sets for the workflow dashboard.
+     *
+     * @param  array<string, mixed>  $params
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function actionableSets(array $params = []): object
+    {
+        $url = '/v1/workflow/actionable-sets';
+        if (! empty($params)) {
+            $url .= '?'.http_build_query($params);
+        }
+
+        return $this->makeRequest($url, 'GET');
+    }
+}

--- a/src/Schemas/WorkflowSchema.php
+++ b/src/Schemas/WorkflowSchema.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace CardTechie\TradingCardApiSdk\Schemas;
+
+/**
+ * Schema for Workflow API responses
+ */
+class WorkflowSchema extends BaseSchema
+{
+    /**
+     * Get validation rules for a single Workflow response
+     */
+    public function getRules(): array
+    {
+        return $this->mergeRules(
+            $this->getJsonApiRules(),
+            $this->getMetaLinksRules()
+        );
+    }
+
+    /**
+     * Get validation rules for Workflow collection responses (e.g. actionable-sets)
+     */
+    public function getCollectionRules(): array
+    {
+        return $this->mergeRules(
+            $this->getJsonApiCollectionRules(),
+            $this->getMetaLinksRules()
+        );
+    }
+}

--- a/src/TradingCardApi.php
+++ b/src/TradingCardApi.php
@@ -15,6 +15,7 @@ use CardTechie\TradingCardApiSdk\Resources\Set;
 use CardTechie\TradingCardApiSdk\Resources\SetSource;
 use CardTechie\TradingCardApiSdk\Resources\Stats;
 use CardTechie\TradingCardApiSdk\Resources\Team;
+use CardTechie\TradingCardApiSdk\Resources\Workflow;
 use CardTechie\TradingCardApiSdk\Resources\Year;
 use GuzzleHttp\Client;
 
@@ -302,5 +303,13 @@ class TradingCardApi
     public function stats(): Stats
     {
         return $this->createResource(Stats::class);
+    }
+
+    /**
+     * Retrieve the workflow resource.
+     */
+    public function workflow(): Workflow
+    {
+        return $this->createResource(Workflow::class);
     }
 }

--- a/tests/Resources/WorkflowResourceTest.php
+++ b/tests/Resources/WorkflowResourceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Resources\Workflow;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+
+beforeEach(function () {
+    $this->app['config']->set('tradingcardapi', [
+        'url' => 'https://api.example.com',
+        'ssl_verify' => true,
+        'client_id' => 'test-client-id',
+        'client_secret' => 'test-client-secret',
+    ]);
+
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+
+    $this->mockHandler = new MockHandler;
+    $handlerStack = HandlerStack::create($this->mockHandler);
+    $this->client = new Client(['handler' => $handlerStack]);
+    $this->workflowResource = new Workflow($this->client);
+});
+
+it('can be instantiated with client', function () {
+    expect($this->workflowResource)->toBeInstanceOf(Workflow::class);
+});
+
+it('can get actionable sets', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                [
+                    'id' => '1',
+                    'type' => 'sets',
+                    'attributes' => [
+                        'name' => '2024 Topps Baseball',
+                        'status' => 'draft',
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'type' => 'sets',
+                    'attributes' => [
+                        'name' => '2024 Panini Football',
+                        'status' => 'draft',
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->actionableSets();
+
+    expect($result)->toBeObject();
+    expect($result->data)->toBeArray();
+    expect($result->data)->toHaveCount(2);
+    expect($result->data[0]->id)->toBe('1');
+    expect($result->data[0]->attributes->name)->toBe('2024 Topps Baseball');
+    expect($result->data[1]->id)->toBe('2');
+    expect($result->data[1]->attributes->name)->toBe('2024 Panini Football');
+});
+
+it('can get actionable sets with params', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                [
+                    'id' => '3',
+                    'type' => 'sets',
+                    'attributes' => [
+                        'name' => '2024 Topps Baseball',
+                        'status' => 'draft',
+                        'sport' => 'baseball',
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->actionableSets(['filter[sport]' => 'baseball']);
+
+    expect($result)->toBeObject();
+    expect($result->data)->toBeArray();
+    expect($result->data)->toHaveCount(1);
+    expect($result->data[0]->id)->toBe('3');
+    expect($result->data[0]->attributes->sport)->toBe('baseball');
+});

--- a/tests/TradingCardApiTest.php
+++ b/tests/TradingCardApiTest.php
@@ -12,6 +12,7 @@ use CardTechie\TradingCardApiSdk\Resources\Set;
 use CardTechie\TradingCardApiSdk\Resources\SetSource;
 use CardTechie\TradingCardApiSdk\Resources\Stats;
 use CardTechie\TradingCardApiSdk\Resources\Team;
+use CardTechie\TradingCardApiSdk\Resources\Workflow;
 use CardTechie\TradingCardApiSdk\Resources\Year;
 use CardTechie\TradingCardApiSdk\TradingCardApi;
 use GuzzleHttp\Client;
@@ -107,6 +108,12 @@ it('returns set source resource', function () {
     $api = new TradingCardApi;
     $setSource = $api->setSource();
     expect($setSource)->toBeInstanceOf(SetSource::class);
+});
+
+it('returns workflow resource', function () {
+    $api = new TradingCardApi;
+    $workflow = $api->workflow();
+    expect($workflow)->toBeInstanceOf(Workflow::class);
 });
 
 it('creates guzzle client with correct configuration', function () {


### PR DESCRIPTION
## Summary

- Adds new `Workflow` resource class (`src/Resources/Workflow.php`) with `actionableSets()` method calling `GET /v1/workflow/actionable-sets`
- Registers `workflow()` accessor on `TradingCardApi` via `createResource()`
- Adds 3 Pest tests covering instantiation, basic call, and call with query params

## Usage

```php
TradingCardApi::workflow()->actionableSets();
TradingCardApi::workflow()->actionableSets(['filter[sport]' => 'baseball']);
```

## Test plan

- [x] 648 tests pass
- [x] PHPStan Level 4: no errors
- [x] Laravel Pint: all 143 files pass formatting check

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)