### PR TITLE
fix: wire setAuthInfo() auth plumbing into retrieveToken() (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Workflow` resource with `actionableSets()` method for `GET /v1/workflow/actionable-sets` endpoint (#167)
 - `workflow()` method to `Set` resource for `GET /v1/sets/{id}/workflow` endpoint (#166)
 
+### Fixed
+
+- `setAuthInfo()` auth plumbing now wired into `retrieveToken()`: PAT tokens used directly (no OAuth request), instance OAuth credentials respected over config, `$scope` stored and included in cache key to prevent scope collisions (#169)
+
 ## [0.1.18] - 2026-01-22
 
 ### Added

--- a/src/Resources/Traits/ApiRequest.php
+++ b/src/Resources/Traits/ApiRequest.php
@@ -2,6 +2,7 @@
 
 namespace CardTechie\TradingCardApiSdk\Resources\Traits;
 
+use CardTechie\TradingCardApiSdk\Exceptions\AuthenticationException;
 use CardTechie\TradingCardApiSdk\Services\ErrorResponseParser;
 use CardTechie\TradingCardApiSdk\Services\ResponseValidator;
 use Psr\Http\Message\ResponseInterface;
@@ -155,6 +156,9 @@ trait ApiRequest
     {
         // PAT path: skip OAuth entirely, use token directly
         if ($this->authType === 'pat') {
+            if (empty($this->personalAccessToken)) {
+                throw new AuthenticationException('Personal Access Token is required when using PAT authentication.');
+            }
             $this->token = $this->personalAccessToken;
 
             return;

--- a/src/Resources/Traits/ApiRequest.php
+++ b/src/Resources/Traits/ApiRequest.php
@@ -69,6 +69,13 @@ trait ApiRequest
     private $oauthClientSecret;
 
     /**
+     * OAuth2 Scope
+     *
+     * @var string|null
+     */
+    private $scope;
+
+    /**
      * Set authentication information on this resource.
      */
     public function setAuthInfo(string $authType, ?string $personalAccessToken, ?string $clientId, ?string $clientSecret, ?string $scope = null): void
@@ -77,6 +84,7 @@ trait ApiRequest
         $this->personalAccessToken = $personalAccessToken;
         $this->oauthClientId = $clientId;
         $this->oauthClientSecret = $clientSecret;
+        $this->scope = $scope;
     }
 
     /**
@@ -145,8 +153,22 @@ trait ApiRequest
      */
     private function retrieveToken(): void
     {
+        // PAT path: skip OAuth entirely, use token directly
+        if ($this->authType === 'pat') {
+            $this->token = $this->personalAccessToken;
+
+            return;
+        }
+
+        // OAuth2 path: use instance credentials if set, fall back to config
         $config = config('tradingcardapi');
-        $tokenKey = 'tcapi_token_'.md5($config['client_id'].'|'.$config['client_secret']);
+        $clientId = $this->oauthClientId ?? $config['client_id'];
+        $clientSecret = $this->oauthClientSecret ?? $config['client_secret'];
+        $scope = $this->scope ?? $config['scope'] ?? '';
+
+        // Include scope in cache key so different scopes don't collide
+        $tokenKey = 'tcapi_token_'.md5($clientId.'|'.$clientSecret.'|'.$scope);
+
         if (cache()->has($tokenKey)) {
             $this->token = cache()->get($tokenKey);
 
@@ -154,21 +176,18 @@ trait ApiRequest
         }
 
         $url = '/oauth/token';
-        $headers = [
-            'Accept' => 'application/json',
-            'Content-Type' => 'application/x-www-form-urlencoded',
+        $request = [
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ],
+            'form_params' => [
+                'grant_type' => 'client_credentials',
+                'client_id' => $clientId,
+                'client_secret' => $clientSecret,
+                'scope' => $scope,
+            ],
         ];
-
-        $body = [
-            'grant_type' => 'client_credentials',
-            'client_id' => $config['client_id'],
-            'client_secret' => $config['client_secret'],
-            'scope' => $config['scope'] ?? '',
-        ];
-
-        $request = [];
-        $request['headers'] = $headers;
-        $request['form_params'] = $body;
 
         try {
             $response = $this->doRequest($url, 'POST', $request);
@@ -179,9 +198,7 @@ trait ApiRequest
             throw $this->errorParser->parseGuzzleException($exception);
         }
 
-        $body = (string) $response->getBody();
-        $json = json_decode($body);
-
+        $json = json_decode((string) $response->getBody());
         $this->token = $json->access_token;
         cache()->put($tokenKey, $this->token, 60);
     }

--- a/tests/Resources/AttributeResourceTest.php
+++ b/tests/Resources/AttributeResourceTest.php
@@ -17,7 +17,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/BrandResourceTest.php
+++ b/tests/Resources/BrandResourceTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/CardImageResourceTest.php
+++ b/tests/Resources/CardImageResourceTest.php
@@ -19,7 +19,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/GenreResourceTest.php
+++ b/tests/Resources/GenreResourceTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/ManufacturerResourceTest.php
+++ b/tests/Resources/ManufacturerResourceTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/ObjectAttributeResourceTest.php
+++ b/tests/Resources/ObjectAttributeResourceTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/PlayerteamResourceTest.php
+++ b/tests/Resources/PlayerteamResourceTest.php
@@ -17,7 +17,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/SetResourceTest.php
+++ b/tests/Resources/SetResourceTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/SetSourceResourceTest.php
+++ b/tests/Resources/SetSourceResourceTest.php
@@ -20,7 +20,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);
@@ -415,7 +415,7 @@ it('sends correct JSON:API type in create request payload', function () {
     $client = new Client(['handler' => $handlerStack]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $setSourceResource = new SetSource($client);
     $setSourceResource->create(['source_url' => 'https://example.com/source', 'source_type' => 'checklist']);
@@ -455,7 +455,7 @@ it('sends correct JSON:API type in update request payload', function () {
     $client = new Client(['handler' => $handlerStack]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $setSourceResource = new SetSource($client);
     $setSourceResource->update('123', ['source_url' => 'https://example.com/updated-source']);

--- a/tests/Resources/StatsResourceTest.php
+++ b/tests/Resources/StatsResourceTest.php
@@ -22,7 +22,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/TeamResourceTest.php
+++ b/tests/Resources/TeamResourceTest.php
@@ -17,7 +17,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/Traits/ApiRequestErrorHandlingTest.php
+++ b/tests/Resources/Traits/ApiRequestErrorHandlingTest.php
@@ -40,7 +40,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     // Mock cache function for testing
     if (! function_exists('cache')) {
@@ -205,7 +205,7 @@ it('provides access to error parser instance', function () {
     $client = new Client(['handler' => $handlerStack]);
 
     // Clear cached token
-    $tokenKey = 'tcapi_token_'.md5('test-client-id|test-client-secret');
+    $tokenKey = 'tcapi_token_'.md5('test-client-id|test-client-secret|');
     cache()->put($tokenKey, null, 0);
 
     $apiRequest = new ApiRequestTestClass($client);
@@ -237,7 +237,7 @@ it('handles authentication errors during token retrieval', function () {
     $client = new Client(['handler' => $handlerStack]);
 
     // Create fresh instance without cached token
-    $tokenKey = 'tcapi_token_'.md5('test-client-id|test-client-secret');
+    $tokenKey = 'tcapi_token_'.md5('test-client-id|test-client-secret|');
     cache()->put($tokenKey, null, 0); // Clear token
 
     $apiRequest = new ApiRequestTestClass($client);
@@ -266,7 +266,7 @@ it('successfully makes request when no errors occur', function () {
     $client = new Client(['handler' => $handlerStack]);
 
     // Clear cached token to force token retrieval
-    $tokenKey = 'tcapi_token_'.md5('test-client-id|test-client-secret');
+    $tokenKey = 'tcapi_token_'.md5('test-client-id|test-client-secret|');
     cache()->put($tokenKey, null, 0);
 
     $apiRequest = new ApiRequestTestClass($client);

--- a/tests/Resources/WorkflowResourceTest.php
+++ b/tests/Resources/WorkflowResourceTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
         'client_secret' => 'test-client-secret',
     ]);
 
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Resources/YearResourceTest.php
+++ b/tests/Resources/YearResourceTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
     ]);
 
     // Pre-populate cache with token to avoid OAuth requests
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'test-token', 60);
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'test-token', 60);
 
     $this->mockHandler = new MockHandler;
     $handlerStack = HandlerStack::create($this->mockHandler);

--- a/tests/Traits/ApiRequestTest.php
+++ b/tests/Traits/ApiRequestTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use CardTechie\TradingCardApiSdk\Exceptions\AuthenticationException;
 use CardTechie\TradingCardApiSdk\Resources\Traits\ApiRequest;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
@@ -420,6 +421,28 @@ it('uses PAT directly without making OAuth token request', function () {
 
     expect($result)->toBeObject();
     expect($result->data->id)->toBe('123');
+});
+
+it('throws AuthenticationException when PAT is null', function () {
+    $client = m::mock(Client::class);
+    $client->shouldNotReceive('request');
+
+    $instance = new TestApiRequestClass($client);
+    $instance->setAuthInfo('pat', null, null, null);
+
+    expect(fn () => $instance->testMakeRequest('/test'))
+        ->toThrow(AuthenticationException::class, 'Personal Access Token is required');
+});
+
+it('throws AuthenticationException when PAT is empty string', function () {
+    $client = m::mock(Client::class);
+    $client->shouldNotReceive('request');
+
+    $instance = new TestApiRequestClass($client);
+    $instance->setAuthInfo('pat', '', null, null);
+
+    expect(fn () => $instance->testMakeRequest('/test'))
+        ->toThrow(AuthenticationException::class, 'Personal Access Token is required');
 });
 
 it('uses instance OAuth credentials over config credentials', function () {

--- a/tests/Traits/ApiRequestTest.php
+++ b/tests/Traits/ApiRequestTest.php
@@ -67,8 +67,8 @@ it('can make a request with token retrieval', function () {
 });
 
 it('uses cached token when available', function () {
-    // Set a cached token
-    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret'), 'cached-token', 60);
+    // Set a cached token — key now includes scope (empty string by default)
+    cache()->put('tcapi_token_'.md5('test-client-id|test-client-secret|'), 'cached-token', 60);
 
     $client = m::mock(Client::class);
 
@@ -396,6 +396,134 @@ it('does not set Content-Type header for DELETE requests', function () {
     $result = $instance->testMakeRequest('/v1/cards/123', 'DELETE');
 
     expect($result)->toBeInstanceOf(stdClass::class);
+});
+
+it('uses PAT directly without making OAuth token request', function () {
+    $client = m::mock(Client::class);
+
+    $apiResponse = new GuzzleResponse(200, [], json_encode(['data' => ['id' => '123']]));
+
+    // Should NOT make an OAuth token request
+    $client->shouldNotReceive('request')->with('POST', '/oauth/token', m::type('array'));
+
+    $client->shouldReceive('request')
+        ->with('GET', '/test', m::on(function ($request) {
+            return isset($request['headers']['Authorization']) &&
+                   $request['headers']['Authorization'] === 'Bearer my-pat';
+        }))
+        ->once()
+        ->andReturn($apiResponse);
+
+    $instance = new TestApiRequestClass($client);
+    $instance->setAuthInfo('pat', 'my-pat', null, null);
+    $result = $instance->testMakeRequest('/test');
+
+    expect($result)->toBeObject();
+    expect($result->data->id)->toBe('123');
+});
+
+it('uses instance OAuth credentials over config credentials', function () {
+    $client = m::mock(Client::class);
+
+    $tokenResponse = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'override-token',
+        'token_type' => 'Bearer',
+    ]));
+
+    $apiResponse = new GuzzleResponse(200, [], json_encode(['data' => ['id' => '123']]));
+
+    $client->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::on(function ($request) {
+            return isset($request['form_params']['client_id']) &&
+                   $request['form_params']['client_id'] === 'override-id' &&
+                   $request['form_params']['client_secret'] === 'override-secret';
+        }))
+        ->once()
+        ->andReturn($tokenResponse);
+
+    $client->shouldReceive('request')
+        ->with('GET', '/test', m::type('array'))
+        ->once()
+        ->andReturn($apiResponse);
+
+    $instance = new TestApiRequestClass($client);
+    $instance->setAuthInfo('oauth2', null, 'override-id', 'override-secret');
+    $result = $instance->testMakeRequest('/test');
+
+    expect($result)->toBeObject();
+});
+
+it('includes scope in OAuth request when set via setAuthInfo', function () {
+    $client = m::mock(Client::class);
+
+    $tokenResponse = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'scoped-token',
+        'token_type' => 'Bearer',
+    ]));
+
+    $apiResponse = new GuzzleResponse(200, [], json_encode(['data' => ['id' => '123']]));
+
+    $client->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::on(function ($request) {
+            return isset($request['form_params']['scope']) &&
+                   $request['form_params']['scope'] === 'write:cards';
+        }))
+        ->once()
+        ->andReturn($tokenResponse);
+
+    $client->shouldReceive('request')
+        ->with('GET', '/test', m::type('array'))
+        ->once()
+        ->andReturn($apiResponse);
+
+    $instance = new TestApiRequestClass($client);
+    $instance->setAuthInfo('oauth2', null, 'test-client-id', 'test-client-secret', 'write:cards');
+    $result = $instance->testMakeRequest('/test');
+
+    expect($result)->toBeObject();
+});
+
+it('uses separate cache keys for different scopes', function () {
+    $tokenResponse1 = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'token-scope-a',
+        'token_type' => 'Bearer',
+    ]));
+
+    $tokenResponse2 = new GuzzleResponse(200, [], json_encode([
+        'access_token' => 'token-scope-b',
+        'token_type' => 'Bearer',
+    ]));
+
+    $apiResponse = new GuzzleResponse(200, [], json_encode(['data' => ['id' => '123']]));
+
+    $client1 = m::mock(Client::class);
+    $client1->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::on(fn ($r) => $r['form_params']['scope'] === 'scope-a'))
+        ->once()
+        ->andReturn($tokenResponse1);
+    $client1->shouldReceive('request')->with('GET', '/test', m::type('array'))->once()->andReturn($apiResponse);
+
+    $client2 = m::mock(Client::class);
+    $client2->shouldReceive('request')
+        ->with('POST', '/oauth/token', m::on(fn ($r) => $r['form_params']['scope'] === 'scope-b'))
+        ->once()
+        ->andReturn($tokenResponse2);
+    $client2->shouldReceive('request')->with('GET', '/test', m::type('array'))->once()->andReturn($apiResponse);
+
+    $instance1 = new TestApiRequestClass($client1);
+    $instance1->setAuthInfo('oauth2', null, 'test-client-id', 'test-client-secret', 'scope-a');
+    $instance1->testMakeRequest('/test');
+
+    $instance2 = new TestApiRequestClass($client2);
+    $instance2->setAuthInfo('oauth2', null, 'test-client-id', 'test-client-secret', 'scope-b');
+    $instance2->testMakeRequest('/test');
+
+    $keyA = 'tcapi_token_'.md5('test-client-id|test-client-secret|scope-a');
+    $keyB = 'tcapi_token_'.md5('test-client-id|test-client-secret|scope-b');
+
+    expect($keyA)->not->toBe($keyB);
+    expect(cache()->get($keyA))->toBe('token-scope-a');
+    expect(cache()->get($keyB))->toBe('token-scope-b');
 });
 
 it('allows custom Content-Type header to override default for POST requests', function () {


### PR DESCRIPTION
## Summary

- **PAT auth now works**: `setAuthInfo('pat', $token, ...)` sets the Bearer token directly — no OAuth request is made
- **Instance OAuth credentials respected**: `oauthClientId`/`oauthClientSecret` set via `setAuthInfo()` are used in the OAuth request instead of always reading from config
- **`$scope` stored and applied**: was accepted by `setAuthInfo()` but never assigned; now stored and passed in the OAuth token request
- **Scope-aware cache key**: token cache key is now `md5($clientId.'|'.$clientSecret.'|'.$scope)` so different scopes get separate cached tokens

## Test plan

- [x] `it uses PAT directly without making OAuth token request` — no `/oauth/token` call, Bearer uses PAT value
- [x] `it uses instance OAuth credentials over config credentials` — OAuth request uses override-id/override-secret
- [x] `it includes scope in OAuth request when set via setAuthInfo` — form_params scope matches instance scope
- [x] `it uses separate cache keys for different scopes` — distinct cache entries per scope
- [x] Updated `it uses cached token when available` — reflects new key format with scope suffix
- [x] All 17 ApiRequest tests pass
- [x] PHPStan Level 4: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)