### PR TITLE
fix: skip JSON:API validation for sub-resource endpoints (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sub-resource endpoints (`/v1/sets/{id}/workflow`, `/v1/sets/{id}/checklist`, etc.) no longer trigger JSON:API validation — `extractResourceType()` now returns `null` for paths with 3+ segments after the version prefix, preventing `ValidationException` in `strict_mode: true` (#170)
 - `setAuthInfo()` auth plumbing now wired into `retrieveToken()`: PAT tokens used directly (no OAuth request), instance OAuth credentials respected over config, `$scope` stored and included in cache key to prevent scope collisions (#169)
 
 ## [0.1.18] - 2026-01-22

--- a/src/Resources/Traits/ApiRequest.php
+++ b/src/Resources/Traits/ApiRequest.php
@@ -257,6 +257,12 @@ trait ApiRequest
 
         // Match common API patterns
         if (preg_match('#/v\d+/([^/]+)#', $path, $matches)) {
+            // Sub-resource paths (e.g. /v1/sets/123/workflow) are not JSON:API
+            // resource responses — skip validation to avoid false failures
+            if (preg_match('#/v\d+/[^/]+/[^/]+/.+#', $path)) {
+                return null;
+            }
+
             $resource = $matches[1];
 
             // Normalize resource names

--- a/tests/Resources/SetResourceTest.php
+++ b/tests/Resources/SetResourceTest.php
@@ -438,6 +438,48 @@ it('can handle large pagination in list', function () {
     expect($result->currentPage())->toBe(25);
 });
 
+it('does not throw in strict_mode for workflow sub-resource endpoint', function () {
+    $this->app['config']->set('tradingcardapi.validation.enabled', true);
+    $this->app['config']->set('tradingcardapi.validation.strict_mode', true);
+
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'workflow' => [
+                'priority' => 'high',
+                'current_step' => 'validate',
+                'todos' => [
+                    ['step' => 'discover_sources', 'status' => 'completed'],
+                    ['step' => 'validate', 'status' => 'in_progress'],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->setResource->workflow('123');
+
+    expect($result)->toBeObject();
+    expect($result->workflow)->toBeObject();
+    expect($result->workflow->priority)->toBe('high');
+});
+
+it('does not throw in strict_mode for checklist sub-resource endpoint', function () {
+    $this->app['config']->set('tradingcardapi.validation.enabled', true);
+    $this->app['config']->set('tradingcardapi.validation.strict_mode', true);
+
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'checklist' => ['card1', 'card2'],
+                'missing' => ['card3'],
+            ],
+        ]))
+    );
+
+    $result = $this->setResource->checklist('123');
+
+    expect($result)->toBeObject();
+});
+
 it('can add checklist with complex request structure', function () {
     $this->mockHandler->append(
         new GuzzleResponse(200, [], json_encode([

--- a/tests/Resources/Traits/ApiRequestValidationTest.php
+++ b/tests/Resources/Traits/ApiRequestValidationTest.php
@@ -57,7 +57,7 @@ it('extracts resource type from API URLs correctly', function () {
     expect($resource->testExtractResourceType('/v1/cards'))->toBe('card');
     expect($resource->testExtractResourceType('/v1/cards/123'))->toBe('card');
     expect($resource->testExtractResourceType('/v1/players'))->toBe('player');
-    expect($resource->testExtractResourceType('/v1/sets/456/checklist'))->toBe('set');
+    expect($resource->testExtractResourceType('/v1/sets/456/checklist'))->toBeNull();
     expect($resource->testExtractResourceType('/v1/genres'))->toBe('genre');
     expect($resource->testExtractResourceType('/v1/object-attributes'))->toBe('objectattribute');
     expect($resource->testExtractResourceType('/v1/playerteams'))->toBe('playerteam');


### PR DESCRIPTION
## Summary

- `extractResourceType()` now returns `null` for sub-resource paths (3+ segments after the version prefix, e.g. `/v1/sets/123/workflow`), causing `validateResponse()` to skip validation entirely
- Fixes `ValidationException` thrown in `strict_mode: true` for `workflow()`, `checklist()`, `addMissingCards()`, and `addChecklist()` on the `Set` resource
- Updates existing `extractResourceType` unit test to assert `null` for sub-resource paths

## Test plan

- [ ] `make test` — all 657 existing tests pass
- [ ] Two new strict-mode tests added to `SetResourceTest`: `workflow()` and `checklist()` with `strict_mode: true` no longer throw
- [ ] `make analyse` — PHPStan Level 4 zero errors
- [ ] `make format-check` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)