### PR TITLE
fix: handle single-object relationships in Model::__toString() (#165)

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -118,6 +118,12 @@ class Model
         $output = $this->attributes;
 
         foreach ($this->relationships as $type => $relations) {
+            if (is_object($relations) && property_exists($relations, 'attributes')) {
+                $output[$type] = $relations->attributes;
+
+                continue;
+            }
+
             foreach ($relations as $relation) {
                 if (is_array($relation) && array_key_exists('attributes', $relation)) {
                     $output[$type][] = $relation['attributes'];

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -106,6 +106,20 @@ it('converts to string with relationships', function () {
     expect($decoded['users'])->toHaveCount(2);
 });
 
+it('converts to string with single-object relationship', function () {
+    $model = new Model(['id' => '123']);
+    $genre = (object) ['attributes' => ['id' => 'abc', 'name' => 'Baseball']];
+
+    $model->setRelationships(['genre' => $genre]);
+
+    $result = (string) $model;
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('id', '123');
+    expect($decoded)->toHaveKey('genre');
+    expect($decoded['genre'])->toBe(['id' => 'abc', 'name' => 'Baseball']);
+});
+
 it('handles custom attribute accessors', function () {
     $customModel = new class(['first_name' => 'John', 'last_name' => 'Doe']) extends Model
     {


### PR DESCRIPTION
## Summary

- Fixes `Model::__toString()` silently dropping single-object relationships (e.g. `genre` on `Set`)
- Adds a guard before the inner `foreach` that checks if the relationship value is a single object rather than a collection, and serializes it directly as a flat object
- Adds a test covering the single-object relationship case

## Test plan

- [x] New test `converts to string with single-object relationship` verifies the fix
- [x] All existing tests pass (658 passed)
- [x] PHPStan Level 4 — no errors
- [x] Laravel Pint — no formatting issues

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)