### PR TITLE
feat: Add SDK methods for workflow endpoints (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Workflow` resource with `actionableSets()` method for `GET /v1/workflow/actionable-sets` endpoint (#167)
 - `workflow()` method to `Set` resource for `GET /v1/sets/{id}/workflow` endpoint (#166)
+- `updateSetTodo(string $todoId, array $attributes)` method to `Workflow` resource for `PATCH /v1/set-todos/{id}` endpoint (#179)
+- `bulkInitializeWorkflow(array $params)` method to `Workflow` resource for `POST /v1/workflow/bulk-initialize` endpoint (#179)
+- `getBulkInitializeStatus(string $jobId)` method to `Workflow` resource for `GET /v1/workflow/bulk-initialize/{job_id}` endpoint (#179)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Workflow` resource with `actionableSets()` method for `GET /v1/workflow/actionable-sets` endpoint (#167)
 - `workflow()` method to `Set` resource for `GET /v1/sets/{id}/workflow` endpoint (#166)
 - `updateSetTodo(string $todoId, array $attributes)` method to `Workflow` resource for `PATCH /v1/set-todos/{id}` endpoint (#179)
-- `bulkInitializeWorkflow(array $params)` method to `Workflow` resource for `POST /v1/workflow/bulk-initialize` endpoint (#179)
+- `bulkInitializeWorkflow(array $params = [])` method to `Workflow` resource for `POST /v1/workflow/bulk-initialize` endpoint (#179)
 - `getBulkInitializeStatus(string $jobId)` method to `Workflow` resource for `GET /v1/workflow/bulk-initialize/{job_id}` endpoint (#179)
 
 ### Changed

--- a/src/Resources/Traits/ApiRequest.php
+++ b/src/Resources/Traits/ApiRequest.php
@@ -292,6 +292,9 @@ trait ApiRequest
                 'object-attributes' => 'objectattribute',
                 'playerteams' => 'playerteam',
                 'stats' => 'stats',
+                // Action-style endpoints that don't return standard JSON:API responses
+                'workflow' => null,
+                'set-todos' => null,
             ];
 
             return $normalizedResources[$resource] ?? $resource;

--- a/src/Resources/Workflow.php
+++ b/src/Resources/Workflow.php
@@ -31,4 +31,53 @@ class Workflow
 
         return $this->makeRequest($url, 'GET');
     }
+
+    /**
+     * Update a workflow step (set-todo) status.
+     *
+     * @param  array<string, mixed>  $attributes
+     *
+     * @throws InvalidArgumentException
+     */
+    public function updateSetTodo(string $todoId, array $attributes): object
+    {
+        $url = sprintf('/v1/set-todos/%s', $todoId);
+        $request = [
+            'json' => [
+                'data' => [
+                    'type' => 'set-todos',
+                    'id' => $todoId,
+                    'attributes' => $attributes,
+                ],
+            ],
+        ];
+
+        return $this->makeRequest($url, 'PATCH', $request);
+    }
+
+    /**
+     * Bulk initialize workflow todos for existing sets.
+     *
+     * @param  array<string, mixed>  $params
+     *
+     * @throws InvalidArgumentException
+     */
+    public function bulkInitializeWorkflow(array $params = []): object
+    {
+        $request = ! empty($params) ? ['json' => $params] : [];
+
+        return $this->makeRequest('/v1/workflow/bulk-initialize', 'POST', $request);
+    }
+
+    /**
+     * Check the status of a bulk initialization job.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getBulkInitializeStatus(string $jobId): object
+    {
+        $url = sprintf('/v1/workflow/bulk-initialize/%s', $jobId);
+
+        return $this->makeRequest($url, 'GET');
+    }
 }

--- a/tests/Resources/WorkflowResourceTest.php
+++ b/tests/Resources/WorkflowResourceTest.php
@@ -1,10 +1,16 @@
 <?php
 
+use CardTechie\TradingCardApiSdk\Exceptions\AuthenticationException;
+use CardTechie\TradingCardApiSdk\Exceptions\ResourceNotFoundException;
+use CardTechie\TradingCardApiSdk\Exceptions\ServerException;
+use CardTechie\TradingCardApiSdk\Exceptions\ValidationException;
 use CardTechie\TradingCardApiSdk\Resources\Workflow;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Psr\Http\Message\RequestInterface;
 
 beforeEach(function () {
     $this->app['config']->set('tradingcardapi', [
@@ -159,4 +165,265 @@ it('can get bulk initialize status', function () {
     expect($result->data->job_id)->toBe('job-abc-123');
     expect($result->data->status)->toBe('completed');
     expect($result->data->processed)->toBe(150);
+});
+
+// --- updateSetTodo edge cases ---
+
+it('can update a set todo with multiple attributes', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-456',
+                'type' => 'set-todos',
+                'attributes' => [
+                    'status' => 'in_progress',
+                    'priority' => 'high',
+                    'notes' => 'Started processing',
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->updateSetTodo('todo-456', [
+        'status' => 'in_progress',
+        'priority' => 'high',
+        'notes' => 'Started processing',
+    ]);
+
+    expect($result)->toBeObject();
+    expect($result->data->id)->toBe('todo-456');
+    expect($result->data->attributes->status)->toBe('in_progress');
+    expect($result->data->attributes->priority)->toBe('high');
+    expect($result->data->attributes->notes)->toBe('Started processing');
+});
+
+it('can update a set todo with an empty attributes array', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-789',
+                'type' => 'set-todos',
+                'attributes' => [],
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->updateSetTodo('todo-789', []);
+
+    expect($result)->toBeObject();
+    expect($result->data->id)->toBe('todo-789');
+    expect($result->data->type)->toBe('set-todos');
+});
+
+it('throws an exception when updateSetTodo receives a 404', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(404, [], json_encode([
+            'message' => 'Set todo not found',
+        ]))
+    );
+
+    expect(fn () => $this->workflowResource->updateSetTodo('nonexistent-id', ['status' => 'completed']))
+        ->toThrow(ResourceNotFoundException::class);
+});
+
+it('throws an exception when updateSetTodo receives a 422', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(422, [], json_encode([
+            'message' => 'Validation failed',
+            'errors' => [
+                [
+                    'title' => 'Validation Error',
+                    'detail' => 'The status field is invalid',
+                    'source' => ['parameter' => 'status'],
+                ],
+            ],
+        ]))
+    );
+
+    expect(fn () => $this->workflowResource->updateSetTodo('todo-123', ['status' => 'invalid-status']))
+        ->toThrow(ValidationException::class);
+});
+
+it('builds the correct JSON:API envelope for updateSetTodo', function () {
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-123',
+                'type' => 'set-todos',
+                'attributes' => ['status' => 'completed'],
+            ],
+        ])),
+    ]);
+
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $resource->updateSetTodo('todo-123', ['status' => 'completed']);
+
+    $body = json_decode((string) $capturedRequest->getBody(), true);
+    expect($body['data']['type'])->toBe('set-todos');
+    expect($body['data']['id'])->toBe('todo-123');
+    expect($body['data']['attributes'])->toBe(['status' => 'completed']);
+});
+
+// --- bulkInitializeWorkflow edge cases ---
+
+it('can bulk initialize workflow and returns processing status', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(202, [], json_encode([
+            'data' => [
+                'job_id' => 'job-processing-789',
+                'status' => 'processing',
+                'processed' => 50,
+                'total' => 200,
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->bulkInitializeWorkflow(['set_ids' => ['10', '11']]);
+
+    expect($result)->toBeObject();
+    expect($result->data->status)->toBe('processing');
+    expect($result->data->processed)->toBe(50);
+    expect($result->data->total)->toBe(200);
+});
+
+it('throws an exception when bulkInitializeWorkflow receives a 422', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(422, [], json_encode([
+            'message' => 'Validation failed',
+            'errors' => [
+                [
+                    'title' => 'Validation Error',
+                    'detail' => 'set_ids must be an array',
+                    'source' => ['parameter' => 'set_ids'],
+                ],
+            ],
+        ]))
+    );
+
+    expect(fn () => $this->workflowResource->bulkInitializeWorkflow(['set_ids' => 'not-an-array']))
+        ->toThrow(ValidationException::class);
+});
+
+it('throws an exception when bulkInitializeWorkflow receives a 500', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(500, [], json_encode([
+            'message' => 'Internal server error',
+        ]))
+    );
+
+    expect(fn () => $this->workflowResource->bulkInitializeWorkflow())
+        ->toThrow(ServerException::class);
+});
+
+// --- getBulkInitializeStatus edge cases ---
+
+it('can get bulk initialize status when job is still processing', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'job_id' => 'job-abc-123',
+                'status' => 'processing',
+                'processed' => 75,
+                'total' => 150,
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->getBulkInitializeStatus('job-abc-123');
+
+    expect($result)->toBeObject();
+    expect($result->data->status)->toBe('processing');
+    expect($result->data->processed)->toBe(75);
+    expect($result->data->total)->toBe(150);
+});
+
+it('can get bulk initialize status when job has failed', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'job_id' => 'job-failed-001',
+                'status' => 'failed',
+                'processed' => 10,
+                'total' => 150,
+                'error' => 'Unexpected error during processing',
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->getBulkInitializeStatus('job-failed-001');
+
+    expect($result)->toBeObject();
+    expect($result->data->status)->toBe('failed');
+    expect($result->data->error)->toBe('Unexpected error during processing');
+});
+
+it('throws an exception when getBulkInitializeStatus receives a 404 for unknown job', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(404, [], json_encode([
+            'message' => 'Job not found',
+        ]))
+    );
+
+    expect(fn () => $this->workflowResource->getBulkInitializeStatus('nonexistent-job-id'))
+        ->toThrow(ResourceNotFoundException::class);
+});
+
+it('builds the correct URL for getBulkInitializeStatus', function () {
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
+        new GuzzleResponse(200, [], json_encode([
+            'data' => ['job_id' => 'my-job-id', 'status' => 'completed'],
+        ])),
+    ]);
+
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $resource->getBulkInitializeStatus('my-job-id');
+
+    expect((string) $capturedRequest->getUri())->toContain('/v1/workflow/bulk-initialize/my-job-id');
+});
+
+// --- actionableSets edge cases ---
+
+it('can get actionable sets and returns an empty list', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [],
+        ]))
+    );
+
+    $result = $this->workflowResource->actionableSets();
+
+    expect($result)->toBeObject();
+    expect($result->data)->toBeArray();
+    expect($result->data)->toHaveCount(0);
+});
+
+it('throws an exception when actionableSets receives a 401', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(401, [], json_encode([
+            'message' => 'Unauthenticated',
+        ]))
+    );
+
+    expect(fn () => $this->workflowResource->actionableSets())
+        ->toThrow(AuthenticationException::class);
 });

--- a/tests/Resources/WorkflowResourceTest.php
+++ b/tests/Resources/WorkflowResourceTest.php
@@ -86,3 +86,77 @@ it('can get actionable sets with params', function () {
     expect($result->data[0]->id)->toBe('3');
     expect($result->data[0]->attributes->sport)->toBe('baseball');
 });
+
+it('can update a set todo', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-123',
+                'type' => 'set-todos',
+                'attributes' => [
+                    'status' => 'completed',
+                    'completed_at' => '2024-01-01T00:00:00Z',
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->updateSetTodo('todo-123', ['status' => 'completed']);
+
+    expect($result)->toBeObject();
+    expect($result->data->id)->toBe('todo-123');
+    expect($result->data->attributes->status)->toBe('completed');
+});
+
+it('can bulk initialize workflow', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(202, [], json_encode([
+            'data' => [
+                'job_id' => 'job-abc-123',
+                'status' => 'queued',
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->bulkInitializeWorkflow(['set_ids' => ['1', '2', '3']]);
+
+    expect($result)->toBeObject();
+    expect($result->data->job_id)->toBe('job-abc-123');
+    expect($result->data->status)->toBe('queued');
+});
+
+it('can bulk initialize workflow with no params', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(202, [], json_encode([
+            'data' => [
+                'job_id' => 'job-xyz-456',
+                'status' => 'queued',
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->bulkInitializeWorkflow();
+
+    expect($result)->toBeObject();
+    expect($result->data->job_id)->toBe('job-xyz-456');
+});
+
+it('can get bulk initialize status', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'job_id' => 'job-abc-123',
+                'status' => 'completed',
+                'processed' => 150,
+                'total' => 150,
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->getBulkInitializeStatus('job-abc-123');
+
+    expect($result)->toBeObject();
+    expect($result->data->job_id)->toBe('job-abc-123');
+    expect($result->data->status)->toBe('completed');
+    expect($result->data->processed)->toBe(150);
+});

--- a/tests/Resources/WorkflowResourceTest.php
+++ b/tests/Resources/WorkflowResourceTest.php
@@ -401,6 +401,32 @@ it('builds the correct URL for getBulkInitializeStatus', function () {
     expect((string) $capturedRequest->getUri())->toContain('/v1/workflow/bulk-initialize/my-job-id');
 });
 
+it('sends the correct method, URL, and body for bulkInitializeWorkflow', function () {
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
+        new GuzzleResponse(202, [], json_encode([
+            'data' => ['job_id' => 'job-abc', 'status' => 'queued'],
+        ])),
+    ]);
+
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $resource->bulkInitializeWorkflow(['set_ids' => ['1', '2']]);
+
+    expect($capturedRequest->getMethod())->toBe('POST');
+    expect((string) $capturedRequest->getUri())->toContain('/v1/workflow/bulk-initialize');
+    $body = json_decode((string) $capturedRequest->getBody(), true);
+    expect($body['set_ids'])->toBe(['1', '2']);
+});
+
 // --- actionableSets edge cases ---
 
 it('can get actionable sets and returns an empty list', function () {


### PR DESCRIPTION
## Summary

Adds the three missing workflow endpoint SDK methods from API 0.8.0. Two of the five requested endpoints were already implemented in prior PRs (#167, #166).

## New Methods

- `Workflow::updateSetTodo(string $todoId, array $attributes)` → `PATCH /v1/set-todos/{id}`
- `Workflow::bulkInitializeWorkflow(array $params = [])` → `POST /v1/workflow/bulk-initialize`
- `Workflow::getBulkInitializeStatus(string $jobId)` → `GET /v1/workflow/bulk-initialize/{job_id}`

## Previously Implemented (no changes needed)

- `Workflow::actionableSets()` → `GET /v1/workflow/actionable-sets` (PR #167)
- `Set::workflow(string $id)` → `GET /v1/sets/{id}/workflow` (PR #166)

## Changes

- `src/Resources/Workflow.php` — 3 new methods
- `tests/Resources/WorkflowResourceTest.php` — 4 new test cases
- `CHANGELOG.md` — documented in [Unreleased]

## Testing

- [x] All 661 tests pass
- [x] PHPStan Level 4 — no errors
- [x] Laravel Pint format check passes
- [x] Security review completed
- [x] Performance review completed
- [x] Test coverage review completed

Closes #179

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)