### PR TITLE
Add review status support to Workflow resource (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `WorkflowStatus` enum with status constants (`pending`, `in_progress`, `completed`, `skipped`, `review`) (#188)
+- `WorkflowStep` enum with step constants (`discover_sources`, `fetch`, `parse`, `populate`, `validate`, `cleanup`, `publish`) (#188)
+- `getReviewQueue()` method on Workflow resource to query sets blocked for human review (#188)
+- `flagForReview()` and `resolveReview()` helper methods on Workflow resource (#188)
+
 ## [0.2.2] - 2026-04-11
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-04-13
+
 ### Added
 
-- `WorkflowStatus` enum with status constants (`pending`, `in_progress`, `completed`, `skipped`, `review`) (#188)
-- `WorkflowStep` enum with step constants (`discover_sources`, `fetch`, `parse`, `populate`, `validate`, `cleanup`, `publish`) (#188)
-- `getReviewQueue()` method on Workflow resource to query sets blocked for human review (#188)
-- `flagForReview()` and `resolveReview()` helper methods on Workflow resource (#188)
+- Review status support for the Workflow resource with enums and convenience helpers (#188)
 
 ## [0.2.2] - 2026-04-11
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The SDK provides access to the following Trading Card API resources:
 | **SetSources** | Set data sources | `get()`, `list()`, `create()`, `update()`, `delete()`, `forSet($setId)` |
 | **Stats** | Entity statistics and analytics | `get($type)`, `getCounts()`, `getSnapshots()`, `getGrowth()` |
 | **Attributes** | Card attributes | `get()`, `getList()` |
-| **Workflow** | Set workflow management and bulk operations | `actionableSets()`, `updateSetTodo($todoId, $attributes)`, `bulkInitializeWorkflow()`, `getBulkInitializeStatus($jobId)`, `getSetTodos($setId)` |
+| **Workflow** | Set workflow management and bulk operations | `actionableSets()`, `updateSetTodo($todoId, $attributes)`, `bulkInitializeWorkflow()`, `getBulkInitializeStatus($jobId)`, `getSetTodos($setId)`, `getReviewQueue($step, $params)`, `flagForReview($todoId, $reason)`, `resolveReview($todoId, $notes)` |
 | **CardImages** | Card image upload and management | `list()`, `get($id)`, `upload($file, $cardId, $imageType)`, `update($id, $attributes)`, `delete($id)`, `getDownloadUrl($id, $size)` |
 
 ### Stats Resource
@@ -395,6 +395,37 @@ foreach ($result->todos as $todo) {
     echo $todo->status;  // e.g. 'completed'
 }
 // Returns empty todos array when set exists but has no initialized workflow
+
+// --- Review Queue ---
+
+// Get all sets blocked for human review
+$reviewQueue = $api->workflow()->getReviewQueue();
+
+// Filter review queue by workflow step
+$parseReview = $api->workflow()->getReviewQueue('parse');
+
+// With additional params
+$reviewQueue = $api->workflow()->getReviewQueue(null, ['filter[sport]' => 'baseball']);
+
+// Flag a workflow step for human review
+$api->workflow()->flagForReview('todo-id', 'Data quality issue detected');
+
+// Resolve a review (resets to pending)
+$api->workflow()->resolveReview('todo-id');
+$api->workflow()->resolveReview('todo-id', 'Verified card data is correct');
+
+// --- Enums ---
+
+// Use WorkflowStatus enum instead of magic strings
+use CardTechie\TradingCardApiSdk\Enums\WorkflowStatus;
+use CardTechie\TradingCardApiSdk\Enums\WorkflowStep;
+
+$api->workflow()->updateSetTodo('todo-id', [
+    'status' => WorkflowStatus::COMPLETED->value,
+]);
+
+// Filter by step using the enum
+$reviewQueue = $api->workflow()->getReviewQueue(WorkflowStep::PARSE->value);
 ```
 
 ### CardImage Resource

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The SDK provides access to the following Trading Card API resources:
 | **SetSources** | Set data sources | `get()`, `list()`, `create()`, `update()`, `delete()`, `forSet($setId)` |
 | **Stats** | Entity statistics and analytics | `get($type)`, `getCounts()`, `getSnapshots()`, `getGrowth()` |
 | **Attributes** | Card attributes | `get()`, `getList()` |
-| **Workflow** | Set workflow management and bulk operations | `actionableSets()`, `updateSetTodo($todoId, $attributes)`, `bulkInitializeWorkflow()`, `getBulkInitializeStatus($jobId)`, `getSetTodos($setId)`, `getReviewQueue($step, $params)`, `flagForReview($todoId, $reason)`, `resolveReview($todoId, $notes)` |
+| **Workflow** | Set workflow management and bulk operations | `actionableSets()`, `updateSetTodo($todoId, $attributes)`, `bulkInitializeWorkflow()`, `getBulkInitializeStatus($jobId)`, `getSetTodos($setId)`, `getReviewQueue($step?, $params?)`, `flagForReview($todoId, $reason)`, `resolveReview($todoId, $notes?)` |
 | **CardImages** | Card image upload and management | `list()`, `get($id)`, `upload($file, $cardId, $imageType)`, `update($id, $attributes)`, `delete($id)`, `getDownloadUrl($id, $size)` |
 
 ### Stats Resource

--- a/README.md
+++ b/README.md
@@ -416,16 +416,15 @@ $api->workflow()->resolveReview('todo-id', 'Verified card data is correct');
 
 // --- Enums ---
 
-// Use WorkflowStatus enum instead of magic strings
-use CardTechie\TradingCardApiSdk\Enums\WorkflowStatus;
-use CardTechie\TradingCardApiSdk\Enums\WorkflowStep;
-
+// Use WorkflowStatus and WorkflowStep enums instead of magic strings
 $api->workflow()->updateSetTodo('todo-id', [
-    'status' => WorkflowStatus::COMPLETED->value,
+    'status' => \CardTechie\TradingCardApiSdk\Enums\WorkflowStatus::COMPLETED->value,
 ]);
 
 // Filter by step using the enum
-$reviewQueue = $api->workflow()->getReviewQueue(WorkflowStep::PARSE->value);
+$reviewQueue = $api->workflow()->getReviewQueue(
+    \CardTechie\TradingCardApiSdk\Enums\WorkflowStep::PARSE->value
+);
 ```
 
 ### CardImage Resource

--- a/src/Enums/WorkflowStatus.php
+++ b/src/Enums/WorkflowStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CardTechie\TradingCardApiSdk\Enums;
+
+enum WorkflowStatus: string
+{
+    case PENDING = 'pending';
+    case IN_PROGRESS = 'in_progress';
+    case COMPLETED = 'completed';
+    case SKIPPED = 'skipped';
+    case REVIEW = 'review';
+}

--- a/src/Enums/WorkflowStep.php
+++ b/src/Enums/WorkflowStep.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace CardTechie\TradingCardApiSdk\Enums;
+
+enum WorkflowStep: string
+{
+    case DISCOVER_SOURCES = 'discover_sources';
+    case FETCH = 'fetch';
+    case PARSE = 'parse';
+    case POPULATE = 'populate';
+    case VALIDATE = 'validate';
+    case CLEANUP = 'cleanup';
+    case PUBLISH = 'publish';
+}

--- a/src/Resources/Workflow.php
+++ b/src/Resources/Workflow.php
@@ -134,7 +134,7 @@ class Workflow
     {
         return $this->updateSetTodo($todoId, [
             'status' => WorkflowStatus::PENDING->value,
-            'notes' => $notes ?: 'Resolved by human review',
+            'notes' => $notes !== '' ? $notes : 'Resolved by human review',
         ]);
     }
 }

--- a/src/Resources/Workflow.php
+++ b/src/Resources/Workflow.php
@@ -2,6 +2,7 @@
 
 namespace CardTechie\TradingCardApiSdk\Resources;
 
+use CardTechie\TradingCardApiSdk\Enums\WorkflowStatus;
 use CardTechie\TradingCardApiSdk\Resources\Traits\ApiRequest;
 use GuzzleHttp\Client;
 use Psr\SimpleCache\InvalidArgumentException;
@@ -91,5 +92,49 @@ class Workflow
         $url = sprintf('/v1/workflow/sets/%s/todos', $setId);
 
         return $this->makeRequest($url, 'GET');
+    }
+
+    /**
+     * Get all sets currently blocked for human review,
+     * optionally filtered by workflow step.
+     *
+     * @param  array<string, mixed>  $params
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getReviewQueue(?string $step = null, array $params = []): object
+    {
+        $params['status'] = WorkflowStatus::REVIEW->value;
+        if ($step !== null) {
+            $params['step'] = $step;
+        }
+
+        return $this->actionableSets($params);
+    }
+
+    /**
+     * Flag a workflow step (set-todo) for human review.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function flagForReview(string $todoId, string $reason): object
+    {
+        return $this->updateSetTodo($todoId, [
+            'status' => WorkflowStatus::REVIEW->value,
+            'notes' => $reason,
+        ]);
+    }
+
+    /**
+     * Resolve a review by resetting a workflow step (set-todo) back to pending.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function resolveReview(string $todoId, string $notes = ''): object
+    {
+        return $this->updateSetTodo($todoId, [
+            'status' => WorkflowStatus::PENDING->value,
+            'notes' => $notes ?: 'Resolved by human review',
+        ]);
     }
 }

--- a/tests/Enums/WorkflowStatusTest.php
+++ b/tests/Enums/WorkflowStatusTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Enums\WorkflowStatus;
+
+it('has the correct status values', function () {
+    expect(WorkflowStatus::PENDING->value)->toBe('pending');
+    expect(WorkflowStatus::IN_PROGRESS->value)->toBe('in_progress');
+    expect(WorkflowStatus::COMPLETED->value)->toBe('completed');
+    expect(WorkflowStatus::SKIPPED->value)->toBe('skipped');
+    expect(WorkflowStatus::REVIEW->value)->toBe('review');
+});
+
+it('has exactly five cases', function () {
+    expect(WorkflowStatus::cases())->toHaveCount(5);
+});
+
+it('can be created from a valid string value', function () {
+    expect(WorkflowStatus::from('pending'))->toBe(WorkflowStatus::PENDING);
+    expect(WorkflowStatus::from('in_progress'))->toBe(WorkflowStatus::IN_PROGRESS);
+    expect(WorkflowStatus::from('completed'))->toBe(WorkflowStatus::COMPLETED);
+    expect(WorkflowStatus::from('skipped'))->toBe(WorkflowStatus::SKIPPED);
+    expect(WorkflowStatus::from('review'))->toBe(WorkflowStatus::REVIEW);
+});
+
+it('returns null for tryFrom with an invalid value', function () {
+    expect(WorkflowStatus::tryFrom('invalid'))->toBeNull();
+});

--- a/tests/Enums/WorkflowStepTest.php
+++ b/tests/Enums/WorkflowStepTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use CardTechie\TradingCardApiSdk\Enums\WorkflowStep;
+
+it('has the correct step values', function () {
+    expect(WorkflowStep::DISCOVER_SOURCES->value)->toBe('discover_sources');
+    expect(WorkflowStep::FETCH->value)->toBe('fetch');
+    expect(WorkflowStep::PARSE->value)->toBe('parse');
+    expect(WorkflowStep::POPULATE->value)->toBe('populate');
+    expect(WorkflowStep::VALIDATE->value)->toBe('validate');
+    expect(WorkflowStep::CLEANUP->value)->toBe('cleanup');
+    expect(WorkflowStep::PUBLISH->value)->toBe('publish');
+});
+
+it('has exactly seven cases', function () {
+    expect(WorkflowStep::cases())->toHaveCount(7);
+});
+
+it('can be created from a valid string value', function () {
+    expect(WorkflowStep::from('discover_sources'))->toBe(WorkflowStep::DISCOVER_SOURCES);
+    expect(WorkflowStep::from('fetch'))->toBe(WorkflowStep::FETCH);
+    expect(WorkflowStep::from('parse'))->toBe(WorkflowStep::PARSE);
+    expect(WorkflowStep::from('populate'))->toBe(WorkflowStep::POPULATE);
+    expect(WorkflowStep::from('validate'))->toBe(WorkflowStep::VALIDATE);
+    expect(WorkflowStep::from('cleanup'))->toBe(WorkflowStep::CLEANUP);
+    expect(WorkflowStep::from('publish'))->toBe(WorkflowStep::PUBLISH);
+});
+
+it('returns null for tryFrom with an invalid value', function () {
+    expect(WorkflowStep::tryFrom('invalid'))->toBeNull();
+});

--- a/tests/Resources/WorkflowResourceTest.php
+++ b/tests/Resources/WorkflowResourceTest.php
@@ -598,7 +598,9 @@ it('throws an exception when getSetTodos receives a 500', function () {
 // --- getReviewQueue ---
 
 it('can get review queue', function () {
-    $this->mockHandler->append(
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
         new GuzzleResponse(200, [], json_encode([
             'data' => [
                 [
@@ -610,15 +612,25 @@ it('can get review queue', function () {
                     ],
                 ],
             ],
-        ]))
-    );
+        ])),
+    ]);
 
-    $result = $this->workflowResource->getReviewQueue();
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $result = $resource->getReviewQueue();
 
     expect($result)->toBeObject();
     expect($result->data)->toBeArray();
     expect($result->data)->toHaveCount(1);
     expect($result->data[0]->attributes->status)->toBe('review');
+    expect((string) $capturedRequest->getUri())->toContain('status=review');
 });
 
 it('can get review queue filtered by step', function () {
@@ -673,17 +685,29 @@ it('can get review queue with additional params', function () {
 });
 
 it('can get review queue and returns an empty list', function () {
-    $this->mockHandler->append(
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
         new GuzzleResponse(200, [], json_encode([
             'data' => [],
-        ]))
-    );
+        ])),
+    ]);
 
-    $result = $this->workflowResource->getReviewQueue();
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $result = $resource->getReviewQueue();
 
     expect($result)->toBeObject();
     expect($result->data)->toBeArray();
     expect($result->data)->toHaveCount(0);
+    expect((string) $capturedRequest->getUri())->toContain('status=review');
 });
 
 // --- flagForReview ---

--- a/tests/Resources/WorkflowResourceTest.php
+++ b/tests/Resources/WorkflowResourceTest.php
@@ -594,3 +594,254 @@ it('throws an exception when getSetTodos receives a 500', function () {
     expect(fn () => $this->workflowResource->getSetTodos('set-abc'))
         ->toThrow(ServerException::class);
 });
+
+// --- getReviewQueue ---
+
+it('can get review queue', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                [
+                    'id' => '1',
+                    'type' => 'sets',
+                    'attributes' => [
+                        'name' => '2024 Topps Baseball',
+                        'status' => 'review',
+                    ],
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->getReviewQueue();
+
+    expect($result)->toBeObject();
+    expect($result->data)->toBeArray();
+    expect($result->data)->toHaveCount(1);
+    expect($result->data[0]->attributes->status)->toBe('review');
+});
+
+it('can get review queue filtered by step', function () {
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [],
+        ])),
+    ]);
+
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $resource->getReviewQueue('parse');
+
+    $uri = (string) $capturedRequest->getUri();
+    expect($uri)->toContain('status=review');
+    expect($uri)->toContain('step=parse');
+});
+
+it('can get review queue with additional params', function () {
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [],
+        ])),
+    ]);
+
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $resource->getReviewQueue(null, ['filter[sport]' => 'baseball']);
+
+    $uri = (string) $capturedRequest->getUri();
+    expect($uri)->toContain('status=review');
+    expect($uri)->toContain('filter%5Bsport%5D=baseball');
+    expect($uri)->not->toContain('step=');
+});
+
+it('can get review queue and returns an empty list', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [],
+        ]))
+    );
+
+    $result = $this->workflowResource->getReviewQueue();
+
+    expect($result)->toBeObject();
+    expect($result->data)->toBeArray();
+    expect($result->data)->toHaveCount(0);
+});
+
+// --- flagForReview ---
+
+it('can flag a todo for review', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-123',
+                'type' => 'set-todos',
+                'attributes' => [
+                    'status' => 'review',
+                    'notes' => 'Data quality issue detected',
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->flagForReview('todo-123', 'Data quality issue detected');
+
+    expect($result)->toBeObject();
+    expect($result->data->id)->toBe('todo-123');
+    expect($result->data->attributes->status)->toBe('review');
+    expect($result->data->attributes->notes)->toBe('Data quality issue detected');
+});
+
+it('builds the correct JSON:API envelope for flagForReview', function () {
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-456',
+                'type' => 'set-todos',
+                'attributes' => ['status' => 'review', 'notes' => 'Needs review'],
+            ],
+        ])),
+    ]);
+
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $resource->flagForReview('todo-456', 'Needs review');
+
+    $body = json_decode((string) $capturedRequest->getBody(), true);
+    expect($body['data']['type'])->toBe('set-todos');
+    expect($body['data']['id'])->toBe('todo-456');
+    expect($body['data']['attributes']['status'])->toBe('review');
+    expect($body['data']['attributes']['notes'])->toBe('Needs review');
+});
+
+// --- resolveReview ---
+
+it('can resolve a review with default notes', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-789',
+                'type' => 'set-todos',
+                'attributes' => [
+                    'status' => 'pending',
+                    'notes' => 'Resolved by human review',
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->resolveReview('todo-789');
+
+    expect($result)->toBeObject();
+    expect($result->data->id)->toBe('todo-789');
+    expect($result->data->attributes->status)->toBe('pending');
+    expect($result->data->attributes->notes)->toBe('Resolved by human review');
+});
+
+it('can resolve a review with custom notes', function () {
+    $this->mockHandler->append(
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-789',
+                'type' => 'set-todos',
+                'attributes' => [
+                    'status' => 'pending',
+                    'notes' => 'Verified card data is correct',
+                ],
+            ],
+        ]))
+    );
+
+    $result = $this->workflowResource->resolveReview('todo-789', 'Verified card data is correct');
+
+    expect($result)->toBeObject();
+    expect($result->data->attributes->status)->toBe('pending');
+    expect($result->data->attributes->notes)->toBe('Verified card data is correct');
+});
+
+it('builds the correct JSON:API envelope for resolveReview with default notes', function () {
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-789',
+                'type' => 'set-todos',
+                'attributes' => ['status' => 'pending', 'notes' => 'Resolved by human review'],
+            ],
+        ])),
+    ]);
+
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $resource->resolveReview('todo-789');
+
+    $body = json_decode((string) $capturedRequest->getBody(), true);
+    expect($body['data']['type'])->toBe('set-todos');
+    expect($body['data']['id'])->toBe('todo-789');
+    expect($body['data']['attributes']['status'])->toBe('pending');
+    expect($body['data']['attributes']['notes'])->toBe('Resolved by human review');
+});
+
+it('builds the correct JSON:API envelope for resolveReview with custom notes', function () {
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [
+                'id' => 'todo-789',
+                'type' => 'set-todos',
+                'attributes' => ['status' => 'pending', 'notes' => 'Custom note'],
+            ],
+        ])),
+    ]);
+
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new Workflow($client);
+
+    $resource->resolveReview('todo-789', 'Custom note');
+
+    $body = json_decode((string) $capturedRequest->getBody(), true);
+    expect($body['data']['attributes']['status'])->toBe('pending');
+    expect($body['data']['attributes']['notes'])->toBe('Custom note');
+});


### PR DESCRIPTION
## Summary

- Add `WorkflowStatus` and `WorkflowStep` backed string enums to replace magic strings
- Add `getReviewQueue()` convenience method to query sets blocked for human review
- Add `flagForReview()` and `resolveReview()` helper methods on the Workflow resource

## Changes

- **New:** `src/Enums/WorkflowStatus.php` - Status enum (`pending`, `in_progress`, `completed`, `skipped`, `review`)
- **New:** `src/Enums/WorkflowStep.php` - Step enum (`discover_sources`, `fetch`, `parse`, `populate`, `validate`, `cleanup`, `publish`)
- **Modified:** `src/Resources/Workflow.php` - Added 3 new methods
- **New:** `tests/Enums/WorkflowStatusTest.php` - Enum tests
- **New:** `tests/Enums/WorkflowStepTest.php` - Enum tests
- **Modified:** `tests/Resources/WorkflowResourceTest.php` - Tests for all new methods
- **Modified:** `CHANGELOG.md` - Added entries under Unreleased
- **Modified:** `README.md` - Updated resource table and usage examples

## Testing

- [x] All tests pass (702 passed)
- [x] PHPStan Level 4 passes (0 errors)
- [x] Laravel Pint formatting passes (148 files)
- [x] Security review completed
- [x] Performance review completed
- [x] Test coverage review completed

Closes #188

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)