### PR TITLE
Direct Claude to use create_cross_repo_issues MCP tool for issue creation (#203)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -125,6 +125,16 @@ make check          # Verify all quality standards
 
 The README.md is the public face of this repository and should always accurately represent the current state of the project.
 
+## Issue Creation
+
+Always use the `create_cross_repo_issues` MCP tool (from `picklewagon-mcp`) to
+create GitHub issues — do not call `gh issue create` directly, including for
+post-merge follow-ups or ad-hoc work. The MCP tool automatically:
+
+- Runs duplicate detection before creating the issue
+- Performs cross-repo impact analysis and creates linked sub-issues in affected repos
+- Applies the correct project board, labels, and Type field
+
 ## Release Management
 
 **CRITICAL: Packagist Version Management**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **[Issue #203]** Direct Claude to create GitHub issues via the `create_cross_repo_issues` MCP tool instead of `gh issue create` in `.claude/CLAUDE.md`.
+- Direct Claude to create GitHub issues via the `create_cross_repo_issues` MCP tool instead of `gh issue create` in `.claude/CLAUDE.md` (#203).
 
 ## [0.2.4] - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **[Issue #203]** Direct Claude to create GitHub issues via the `create_cross_repo_issues` MCP tool instead of `gh issue create` in `.claude/CLAUDE.md`.
+
 ## [0.2.4] - 2026-04-14
 
 ### Added


### PR DESCRIPTION
## Summary

Add an `## Issue Creation` section to `.claude/CLAUDE.md` so any Claude session operating in this repo creates GitHub issues via the `create_cross_repo_issues` MCP tool from `picklewagon-mcp` instead of raw `gh issue create`. The MCP tool runs duplicate detection, cross-repo impact analysis, and applies project board / label / Type wiring automatically.

This is the `tradingcardapi-sdk-php` sub-issue of picklewagon/picklewagon-mcp#274. Wording matches the section already established in `tradingcardapi-tools` and `tradingcardapi-admin` for consistency across the cardtechie repos.

## Changes

- `.claude/CLAUDE.md` — added new `## Issue Creation` section between `## Important Reminders` and `## Release Management`
- `CHANGELOG.md` — added entry under `## [Unreleased]` → `### Changed`

## Testing

- [x] All tests pass — N/A (documentation-only change; no SDK code touched)
- [x] Lint passes — N/A (no markdown linting configured in this repo; Pint scopes PHP only)
- [x] Build passes — N/A
- [x] Security review completed — inline (Agent tool unavailable in dispatched fork context); no code paths, no auth/input/data surface — clean
- [x] Performance review completed — inline; no execution path changed — clean
- [x] Test coverage review completed — inline; no runtime code changed — no test gap

**Note:** The three parallel review agents were unavailable in this dispatched (`context: fork`) run, so the test-coverage / security / performance reviews were performed inline. The diff is a markdown-only addition (10 lines of instructions + a 4-line CHANGELOG entry) with no code paths, no inputs, no auth surface, and no execution changes — all three review dimensions reduce to "no concerns."

Closes #203

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
