### PR TITLE
Add agent_id filter to AuditLog::getAuditLogs (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **[Issue #210]** Add `agent_id` filter param to `AuditLog::getAuditLogs()`.
+
 ## [0.2.4] - 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ $logs = $api->auditLog()->getAuditLogs();
 $logs = $api->auditLog()->getAuditLogs([
     'auditable_type' => 'Set',
     'auditable_id' => 'set-uuid',
+    'agent_id' => 'agent-uuid',
     'event_type' => 'created',
     'start_date' => '2026-01-01',
     'end_date' => '2026-04-13',

--- a/src/Resources/AuditLog.php
+++ b/src/Resources/AuditLog.php
@@ -27,7 +27,7 @@ class AuditLog
     /**
      * Retrieve a paginated list of audit logs with optional filters
      *
-     * @param  array<string, mixed>  $params  Filter parameters: auditable_type, auditable_id, event_type, start_date, end_date, per_page, page
+     * @param  array<string, mixed>  $params  Filter parameters: auditable_type, auditable_id, agent_id, event_type, start_date, end_date, per_page, page
      *
      * @throws InvalidArgumentException
      */

--- a/tests/Resources/AuditLogResourceTest.php
+++ b/tests/Resources/AuditLogResourceTest.php
@@ -284,6 +284,31 @@ it('includes filter params in the query string', function () {
     expect($uri)->toContain('per_page=25');
 });
 
+it('includes agent_id filter in the query string', function () {
+    $capturedRequest = null;
+
+    $customHandler = new MockHandler([
+        new GuzzleResponse(200, [], json_encode([
+            'data' => [],
+            'meta' => ['pagination' => ['total' => 0, 'per_page' => 50, 'current_page' => 1]],
+        ])),
+    ]);
+
+    $middleware = Middleware::tap(function (RequestInterface $request) use (&$capturedRequest) {
+        $capturedRequest = $request;
+    });
+
+    $handlerStack = HandlerStack::create($customHandler);
+    $handlerStack->push($middleware);
+    $client = new Client(['handler' => $handlerStack]);
+    $resource = new AuditLog($client);
+
+    $resource->getAuditLogs(['agent_id' => 'agent-uuid-1']);
+
+    $uri = (string) $capturedRequest->getUri();
+    expect($uri)->toContain('agent_id=agent-uuid-1');
+});
+
 // --- createAuditEvent request shape ---
 
 it('builds the correct JSON:API envelope for createAuditEvent with attributes', function () {


### PR DESCRIPTION
## Summary

Extends `AuditLog::getAuditLogs()` to accept and forward an `agent_id` filter param to `GET /v1/audit-logs?agent_id=...`. No runtime logic changes were needed — the method already passes all `$params` entries through `http_build_query`; only the `@param` docblock and a new test were required.

## Changes

- `src/Resources/AuditLog.php` — added `agent_id` to the `@param` docblock on `getAuditLogs()`
- `tests/Resources/AuditLogResourceTest.php` — added test asserting `agent_id=agent-uuid-1` appears in the upstream query string
- `CHANGELOG.md` — added entry under `## [Unreleased]`

## Testing

- [x] All tests pass (730 passed, 1 skipped)
- [x] Lint passes
- [x] Build passes
- [x] Security review completed (inline — no findings)
- [x] Performance review completed (inline — no findings)
- [x] Test coverage review completed (inline — new test directly asserts acceptance criteria)

Closes #210

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)